### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@
 [![codecov](https://codecov.io/gh/shipyard-run/cli/branch/master/graph/badge.svg)](https://codecov.io/gh/shipyard-run/cli)
 
 Creating a release:
-To create a relase tag a commit `git tag <semver>` and push this to GitHub `git push origin <semver>` GitHub actions will build and create the release.
+To create a release tag a commit `git tag <semver>` and push this to GitHub `git push origin <semver>` GitHub actions will build and create the release.


### PR DESCRIPTION
relases -> releases typo in readme

There is also a typo in shipyard.run: "Stoping a blueprint" but at first glance I don't see the website code in this repo.