### PR TITLE
Update Shipyard to re-add Nomad capability

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -68,6 +68,9 @@ var runCmd = &cobra.Command{
 
 		// if we have a blueprint show the header
 		if e.Blueprint() != nil {
+			fmt.Println("")
+			fmt.Println("########################################################")
+			fmt.Println("")
 			fmt.Println("Title", e.Blueprint().Title)
 			fmt.Println("Author", e.Blueprint().Author)
 			fmt.Println("")

--- a/pkg/config/nomad_cluster.go
+++ b/pkg/config/nomad_cluster.go
@@ -12,7 +12,6 @@ type NomadCluster struct {
 
 	Networks []NetworkAttachment `hcl:"network,block" json:"networks,omitempty"` // Attach to the correct network // only when Image is specified
 
-	Driver      string  `hcl:"driver" json:"driver,omitempty"`
 	Version     string  `hcl:"version,optional" json:"version,omitempty"`
 	Nodes       int     `hcl:"nodes,optional" json:"nodes,omitempty"`
 	Config      []KV    `hcl:"config,block" json:"config,omitempty"`

--- a/pkg/config/parse_test.go
+++ b/pkg/config/parse_test.go
@@ -2,10 +2,6 @@ package config
 
 import (
 	"os"
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-	errors "golang.org/x/xerrors"
 )
 
 func setup() func() {
@@ -14,17 +10,6 @@ func setup() func() {
 	return func() {
 		os.Unsetenv("SHIPYARD_CONFIG")
 	}
-}
-
-func TestReturnsErrorIfUserNetworkWAN(t *testing.T) {
-	c := New()
-	err := ParseFolder("./examples/network-wan-error", c)
-
-	assert.True(t, errors.Is(err, ErrorWANExists))
-}
-
-func TestReturnsErrorIfDefaultWANInUse(t *testing.T) {
-	// t.Fatal("Pending")
 }
 
 /*

--- a/pkg/providers/cluster.go
+++ b/pkg/providers/cluster.go
@@ -2,52 +2,9 @@ package providers
 
 import (
 	"errors"
-
-	hclog "github.com/hashicorp/go-hclog"
-	"github.com/shipyard-run/shipyard/pkg/clients"
-	"github.com/shipyard-run/shipyard/pkg/config"
 )
 
 var (
 	ErrorClusterDriverNotImplemented = errors.New("driver not implemented")
 	ErrorClusterExists               = errors.New("cluster exists")
 )
-
-// K8sCluster defines a provider which can create Kubernetes clusters
-type K8sCluster struct {
-	config     *config.K8sCluster
-	client     clients.ContainerTasks
-	kubeClient clients.Kubernetes
-	httpClient clients.HTTP
-	log        hclog.Logger
-}
-
-// NewK8sCluster creates a new Kubernetes cluster provider
-func NewK8sCluster(c *config.K8sCluster, cc clients.ContainerTasks, kc clients.Kubernetes, hc clients.HTTP, l hclog.Logger) *K8sCluster {
-	return &K8sCluster{c, cc, kc, hc, l}
-}
-
-// Create implements interface method to create a cluster of the specified type
-func (c *K8sCluster) Create() error {
-	switch c.config.Driver {
-	case "k3s":
-		return c.createK3s()
-	default:
-		return ErrorClusterDriverNotImplemented
-	}
-}
-
-// Destroy implements interface method to destroy a cluster
-func (c *K8sCluster) Destroy() error {
-	switch c.config.Driver {
-	case "k3s":
-		return c.destroyK3s()
-	default:
-		return ErrorClusterDriverNotImplemented
-	}
-}
-
-// Lookup the a clusters current state
-func (c *K8sCluster) Lookup() ([]string, error) {
-	return []string{}, nil
-}

--- a/pkg/providers/cluster_nomad_test.go
+++ b/pkg/providers/cluster_nomad_test.go
@@ -1,36 +1,327 @@
 package providers
 
 import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
 	"testing"
+	"time"
 
-	// "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	"github.com/shipyard-run/shipyard/pkg/clients/mocks"
 	"github.com/shipyard-run/shipyard/pkg/config"
-	// "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-func setupNomadMocks() (config.NomadCluster, *mocks.MockContainerTasks, *mocks.MockHTTP) {
+// setupClusterMocks sets up a happy path for mocks
+func setupNomadClusterMocks() (*config.NomadCluster, *mocks.MockContainerTasks, *mocks.MockHTTP, func()) {
 	md := &mocks.MockContainerTasks{}
-	md.On("FindContainerIDs", mock.Anything, mock.Anything).Return("", nil)
-	md.On("CreateVolume", mock.Anything).Return("", nil)
-	md.On("CreateContainer", mock.Anything).Return("", nil)
+	md.On("FindContainerIDs", mock.Anything, mock.Anything).Return([]string{}, nil)
+	md.On("PullImage", mock.Anything, mock.Anything).Return(nil)
+	md.On("CreateVolume", mock.Anything, mock.Anything).Return("123", nil)
+	md.On("CreateContainer", mock.Anything).Return("containerid", nil)
+	md.On("ContainerLogs", mock.Anything, true, true).Return(
+		ioutil.NopCloser(bytes.NewBufferString("Running kubelet")),
+		nil,
+	)
+	md.On("CopyFromContainer", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	md.On("CopyLocalDockerImageToVolume", mock.Anything, mock.Anything).Return("/images/file.tar.gz", nil)
+	md.On("ExecuteCommand", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	md.On("RemoveContainer", mock.Anything).Return(nil)
+	md.On("RemoveVolume", mock.Anything).Return(nil)
+	md.On("DetachNetwork", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	hc := &mocks.MockHTTP{}
-	hc.On("HealthCheckHTTP", mock.Anything, mock.Anything).Return(nil)
-	hc.On("HealthCheckNomad", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mh := &mocks.MockHTTP{}
+	mh.On("HealthCheckHTTP", mock.Anything, mock.Anything).Return(nil)
+	mh.On("HealthCheckNomad", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	nc := config.NewNomadCluster("nomad_test")
-	nc.Networks = []config.NetworkAttachment{config.NetworkAttachment{Name: "cloud"}}
+	// set the home folder to a temp folder
+	tmpDir, _ := ioutil.TempDir("", "")
+	currentHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
 
-	return *nc, md, hc
+	// copy the config
+	cc := *clusterNomadConfig
+	cn := *clusterNetwork
+
+	c := config.New()
+	c.AddResource(&cc)
+	c.AddResource(&cn)
+
+	return &cc, md, mh, func() {
+		os.Setenv("HOME", currentHome)
+		os.RemoveAll(tmpDir)
+	}
 }
 
-func TestNomadChecksClusterExists(t *testing.T) {
-	// nc, md, hc := setupNomadMocks()
-	// p := NewNomadCluster(nc, md, nil, hc, hclog.NewNullLogger())
+func TestClusterNomadErrorsWhenUnableToLookupIDs(t *testing.T) {
+	md := &mocks.MockContainerTasks{}
+	md.On("FindContainerIDs", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
 
-	// err := p.Create()
-	// assert.NoError(t, err)
-	// md.AssertCalled(t, "FindContainerIDs", nc.Name, nc.Type)
+	p := NewNomadCluster(clusterNomadConfig, md, nil, hclog.NewNullLogger())
+
+	err := p.Create()
+	assert.Error(t, err)
+}
+
+func TestClusterNomadErrorsWhenClusterExists(t *testing.T) {
+	md := &mocks.MockContainerTasks{}
+	md.On("FindContainerIDs", mock.Anything, mock.Anything).Return([]string{"abc"}, nil)
+
+	p := NewNomadCluster(clusterNomadConfig, md, nil, hclog.NewNullLogger())
+
+	err := p.Create()
+	assert.Error(t, err)
+}
+
+func TestClusterNomadPullsImage(t *testing.T) {
+	cc, md, mh, cleanup := setupNomadClusterMocks()
+	defer cleanup()
+
+	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
+
+	err := p.Create()
+	assert.NoError(t, err)
+	md.AssertCalled(t, "PullImage", config.Image{Name: "shipyardrun/nomad:v1.0.0"}, false)
+}
+
+func TestClusterNomadCreatesANewVolume(t *testing.T) {
+	cc, md, mh, cleanup := setupNomadClusterMocks()
+	defer cleanup()
+
+	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
+
+	err := p.Create()
+	assert.NoError(t, err)
+	md.AssertCalled(t, "CreateVolume", clusterConfig.Name)
+}
+
+func TestClusterNomadFailsWhenUnableToCreatesANewVolume(t *testing.T) {
+	cc, md, mh, cleanup := setupNomadClusterMocks()
+	defer cleanup()
+
+	removeOn(&md.Mock, "CreateVolume")
+	md.On("CreateVolume", mock.Anything, mock.Anything).Return("", fmt.Errorf("boom"))
+
+	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
+
+	err := p.Create()
+	assert.Error(t, err)
+	md.AssertCalled(t, "CreateVolume", clusterConfig.Name)
+}
+
+func TestClusterNomadCreatesAServer(t *testing.T) {
+	cc, md, mh, cleanup := setupNomadClusterMocks()
+	defer cleanup()
+
+	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
+
+	err := p.Create()
+	assert.NoError(t, err)
+
+	params := getCalls(&md.Mock, "CreateContainer")[0].Arguments[0].(*config.Container)
+
+	// validate the basic details for the server container
+	assert.Contains(t, params.Name, "server")
+	assert.Contains(t, params.Image.Name, "nomad")
+	assert.Equal(t, clusterNetwork.Name, params.Networks[0].Name)
+	assert.True(t, params.Privileged)
+
+	// validate that the volume is correctly set
+	assert.Equal(t, "123", params.Volumes[0].Source)
+	assert.Equal(t, "/images", params.Volumes[0].Destination)
+	assert.Equal(t, "volume", params.Volumes[0].Type)
+
+	// validate the API port is set
+	assert.GreaterOrEqual(t, params.Ports[0].Local, 4646)
+	assert.GreaterOrEqual(t, params.Ports[0].Host, 64000)
+	assert.Equal(t, "tcp", params.Ports[0].Protocol)
+}
+
+func TestClusterNomadHealthChecksAPI(t *testing.T) {
+	cc, md, mh, cleanup := setupNomadClusterMocks()
+	defer cleanup()
+
+	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
+	startTimeout = 10 * time.Millisecond // reset the startTimeout, do not want to wait 120s
+
+	err := p.Create()
+	assert.NoError(t, err)
+
+	mh.AssertCalled(t, "HealthCheckHTTP", mock.Anything, mock.Anything)
+}
+
+func TestClusterNomadErrorsIfHealthFails(t *testing.T) {
+	cc, md, mh, cleanup := setupNomadClusterMocks()
+	defer cleanup()
+
+	removeOn(&mh.Mock, "HealthCheckHTTP")
+	mh.On("HealthCheckHTTP", mock.Anything, mock.Anything).Return(fmt.Errorf("boom"))
+
+	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
+	startTimeout = 10 * time.Millisecond // reset the startTimeout, do not want to wait 120s
+
+	err := p.Create()
+	assert.Error(t, err)
+}
+
+func TestClusterNomadHealthChecksNomadNodes(t *testing.T) {
+	cc, md, mh, cleanup := setupNomadClusterMocks()
+	defer cleanup()
+
+	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
+	startTimeout = 10 * time.Millisecond // reset the startTimeout, do not want to wait 120s
+
+	err := p.Create()
+	assert.NoError(t, err)
+
+	mh.AssertCalled(t, "HealthCheckNomad", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestClusterNomadErrorsIfHealthNomadNodesFails(t *testing.T) {
+	cc, md, mh, cleanup := setupNomadClusterMocks()
+	defer cleanup()
+
+	removeOn(&mh.Mock, "HealthCheckNomad")
+	mh.On("HealthCheckNomad", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("boom"))
+
+	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
+	startTimeout = 10 * time.Millisecond // reset the startTimeout, do not want to wait 120s
+
+	err := p.Create()
+	assert.Error(t, err)
+}
+
+func TestClusterNomadImportDockerImagesPullsImages(t *testing.T) {
+	cc, md, mh, cleanup := setupNomadClusterMocks()
+	defer cleanup()
+
+	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
+
+	err := p.Create()
+	assert.NoError(t, err)
+	md.AssertCalled(t, "PullImage", clusterConfig.Images[0], false)
+	md.AssertCalled(t, "PullImage", clusterConfig.Images[1], false)
+}
+
+func TestClusterNomadImportDockerCopiesImages(t *testing.T) {
+	cc, md, mh, cleanup := setupNomadClusterMocks()
+	defer cleanup()
+
+	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
+
+	err := p.Create()
+	assert.NoError(t, err)
+	md.AssertCalled(t, "CopyLocalDockerImageToVolume", []string{"consul:1.6.1", "vault:1.6.1"}, "test.volume.shipyard")
+}
+func TestClusterNomadImportDockerCopyImageFailReturnsError(t *testing.T) {
+	cc, md, mh, cleanup := setupNomadClusterMocks()
+	removeOn(&md.Mock, "CopyLocalDockerImageToVolume")
+	md.On("CopyLocalDockerImageToVolume", mock.Anything, mock.Anything).Return("", fmt.Errorf("boom"))
+	defer cleanup()
+
+	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
+
+	err := p.Create()
+	assert.Error(t, err)
+}
+
+func TestClusterNomadImportDockerRunsExecCommand(t *testing.T) {
+	//TODO implement the docker import command
+	t.Skip()
+	cc, md, mh, cleanup := setupNomadClusterMocks()
+	defer cleanup()
+
+	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
+
+	err := p.Create()
+	assert.NoError(t, err)
+	md.AssertCalled(t, "ExecuteCommand", "containerid", mock.Anything, mock.Anything)
+}
+
+func TestClusterNomadImportDockerExecFailReturnsError(t *testing.T) {
+	//TODO implement the docker import command
+	t.Skip()
+	cc, md, mh, cleanup := setupNomadClusterMocks()
+	removeOn(&md.Mock, "ExecuteCommand")
+	md.On("ExecuteCommand", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("boom"))
+	defer cleanup()
+
+	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
+
+	err := p.Create()
+	assert.Error(t, err)
+}
+
+// Destroy Tests
+func TestClusterNomadDestroyGetsIDr(t *testing.T) {
+	cc, md, mh, cleanup := setupNomadClusterMocks()
+	defer cleanup()
+
+	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
+
+	err := p.Destroy()
+	assert.NoError(t, err)
+	md.AssertCalled(t, "FindContainerIDs", clusterNomadConfig.Name, clusterNomadConfig.Type)
+}
+
+func TestClusterNomadDestroyWithFindIDErrorReturnsError(t *testing.T) {
+	cc, md, mh, cleanup := setupNomadClusterMocks()
+	removeOn(&md.Mock, "FindContainerIDs")
+	md.On("FindContainerIDs", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
+	defer cleanup()
+
+	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
+
+	err := p.Destroy()
+	assert.Error(t, err)
+}
+
+func TestClusterNomadDestroyWithNoIDReturns(t *testing.T) {
+	cc, md, mh, cleanup := setupNomadClusterMocks()
+	removeOn(&md.Mock, "FindContainerIDs")
+	md.On("FindContainerIDs", mock.Anything, mock.Anything).Return(nil, nil)
+	defer cleanup()
+
+	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
+
+	err := p.Destroy()
+	assert.NoError(t, err)
+	md.AssertNotCalled(t, "RemoveContainer", mock.Anything)
+}
+
+func TestClusterNomadDestroyRemovesContainer(t *testing.T) {
+	cc, md, mh, cleanup := setupNomadClusterMocks()
+	removeOn(&md.Mock, "FindContainerIDs")
+	md.On("FindContainerIDs", mock.Anything, mock.Anything).Return([]string{"found"}, nil)
+	defer cleanup()
+
+	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
+
+	err := p.Destroy()
+	assert.NoError(t, err)
+	md.AssertCalled(t, "RemoveContainer", mock.Anything)
+}
+
+func TestClusterNomadDestroyRemovesVolume(t *testing.T) {
+	cc, md, mh, cleanup := setupNomadClusterMocks()
+	defer cleanup()
+
+	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
+
+	err := p.Destroy()
+	assert.NoError(t, err)
+	md.AssertCalled(t, "RemoveVolume", "test")
+}
+
+var clusterNomadConfig = &config.NomadCluster{
+	ResourceInfo: config.ResourceInfo{Name: "test", Type: config.TypeNomadCluster},
+	Version:      "v1.0.0",
+	Images: []config.Image{
+		config.Image{Name: "consul:1.6.1"},
+		config.Image{Name: "vault:1.6.1"},
+	},
+	Networks: []config.NetworkAttachment{config.NetworkAttachment{Name: "cloud"}},
 }


### PR DESCRIPTION
**Change log:**

```
* Return error when Resource type defined in the config does not exist
* Fix bug where Containers were not removed from the Docker bridge network on create
* Fix bug where Ingress image was not pulled before creation
* Rewrite Nomad implementation and add tests
* Remove checks for default WAN network as there is no longer a default WAN
```