### PR TITLE
Taint command and improved resume status

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,14 +5,15 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Launch",
+      "name": "Debug",
       "type": "go",
       "request": "launch",
-      "mode": "auto",
-      "program": "main.go",
+      "mode": "debug",
+      "program": "${workspaceFolder}",
       "env": {},
       "args": [
-        "apply"
+        "run",
+        "./functional_tests/test_fixtures/single_container"
       ]
     }
   ]

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,16 @@
+# Change Log
+
+## Version 0.0.0-beta.5
+
+### Introduce taint command and the ability to re-create resources.
+
+Resources can now be tainted using the command `shipyard taint [type] [name]`
+
+When a resource is marked as tained the next run of `shipyard run` will destroy the resource and re-create it.
+This feature is especailly useful when building blueprints, often you require a change to a particular container you run `shipyard destroy`
+to destroy the stack and then `shipyard run` to re-create. Now it is possible to destroy only the affected resource with `shipyard taint`.
+
+### Change behaviour when processing folders
+
+Previously `shipyard run` would recurse into folders, this behaviour causes problems when the sub-folders contain `*.hcl` files which are not
+Shipyard resources. `shipyard run` now only process the top level folder. Sub folder support will be added when we add the `module` feature.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,3 +14,8 @@ to destroy the stack and then `shipyard run` to re-create. Now it is possible to
 
 Previously `shipyard run` would recurse into folders, this behaviour causes problems when the sub-folders contain `*.hcl` files which are not
 Shipyard resources. `shipyard run` now only process the top level folder. Sub folder support will be added when we add the `module` feature.
+
+### Improve handling for failed resources
+
+Resources which fail to create can now be retired by re-running `shipyard run`, any depended resources which were not created due to the failure
+will also be created when the command is run.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,7 @@ func init() {
 	rootCmd.AddCommand(getCmd)
 	rootCmd.AddCommand(destroyCmd)
 	rootCmd.AddCommand(statusCmd)
+	rootCmd.AddCommand(taintCmd)
 	rootCmd.AddCommand(exposeCmd)
 	rootCmd.AddCommand(containerCmd)
 	rootCmd.AddCommand(codeCmd)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -33,22 +33,28 @@ var runCmd = &cobra.Command{
 	Args: cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
-		dst := args[0]
-		fmt.Println("Running configuration from: ", dst)
-		fmt.Println("")
+		dst := ""
+		if len(args) == 1 {
+			dst = args[0]
+		}
 
 		// create a logger
 		log := createLogger()
 
-		// create the shipyard home
-		os.MkdirAll(utils.ShipyardHome(), os.FileMode(0755))
+		if dst != "" {
+			fmt.Println("Running configuration from: ", dst)
+			fmt.Println("")
 
-		if !utils.IsLocalFolder(dst) && !utils.IsHCLFile(dst) {
-			// fetch the remote server from github
-			dst, err = pullRemoteBlueprint(dst)
-			if err != nil {
-				log.Error("Unable to retrieve blueprint", "error", err)
-				return
+			// create the shipyard home
+			os.MkdirAll(utils.ShipyardHome(), os.FileMode(0755))
+
+			if !utils.IsLocalFolder(dst) && !utils.IsHCLFile(dst) {
+				// fetch the remote server from github
+				dst, err = pullRemoteBlueprint(dst)
+				if err != nil {
+					log.Error("Unable to retrieve blueprint", "error", err)
+					return
+				}
 			}
 		}
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,6 +1,12 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
+	"github.com/hokaccha/go-prettyjson"
+	"github.com/shipyard-run/shipyard/pkg/config"
+	"github.com/shipyard-run/shipyard/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -8,8 +14,22 @@ var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show the status of the current stack",
 	Long:  `Show the status of the current stack`,
-	Args: cobra.NoArgs,
+	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Do Stuff Here
+		// load the stack
+		c := config.New()
+		err := c.FromJSON(utils.StatePath())
+		if err != nil {
+			fmt.Println("Unable to load state", err)
+			os.Exit(1)
+		}
+
+		s, err := prettyjson.Marshal(c)
+		if err != nil {
+			fmt.Println("Unable to load state", err)
+			os.Exit(1)
+		}
+
+		fmt.Println(string(s))
 	},
 }

--- a/cmd/taint.go
+++ b/cmd/taint.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/shipyard-run/shipyard/pkg/config"
+	"github.com/shipyard-run/shipyard/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+var taintCmd = &cobra.Command{
+	Use:   "taint [type] [name]",
+	Short: "Taint a resource e.g. 'shipyard taint container test'",
+	Long: `Taint a resouce and mark is to be re-created on the next Apply
+	Example use to remove a container named test
+	shipyard taint container test	
+	`,
+	Args: cobra.ArbitraryArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 2 {
+			fmt.Println("The resource to taint must be specified as an argument")
+			os.Exit(1)
+		}
+
+		c := config.New()
+		err := c.FromJSON(utils.StatePath())
+		if err != nil {
+			fmt.Println("Unable to load state", err)
+			os.Exit(1)
+		}
+
+		r, err := c.FindResource(fmt.Sprintf("%s.%s", args[0], args[1]))
+		if err != nil || r == nil {
+			fmt.Println("Unable to locate resource in the state with name", args[1])
+			os.Exit(1)
+		}
+
+		r.Info().Status = config.PendingModification
+
+		err = c.ToJSON(utils.StatePath())
+		if err != nil {
+			fmt.Println("Unable to save state", err)
+			os.Exit(1)
+		}
+	},
+}

--- a/functional_tests/test_fixtures/single_container/container.hcl
+++ b/functional_tests/test_fixtures/single_container/container.hcl
@@ -10,8 +10,10 @@ container "consul" {
     destination = "/config"
   }
 
-  network    = "network.onprem"
-  ip_address = "10.5.0.200" // optional
+  network {
+    name = "network.onprem"
+    ip_address = "10.5.0.200" // optional
+  }
 
   resources {
     # Max CPU to consume, 1024 is one core, default unlimited
@@ -20,5 +22,10 @@ container "consul" {
     cpu_pin = [1,2]
     # max memory in MB to consume, default unlimited
     memory = 1024
+  }
+
+  env {
+    key ="abc"
+    value = "123"
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -9,12 +9,15 @@ require (
 	github.com/containerd/containerd v1.3.2 // indirect
 	github.com/docker/docker v1.4.2-0.20181221150755-2cb26cfe9cbf
 	github.com/docker/go-connections v0.4.0
+	github.com/fatih/color v1.9.0 // indirect
 	github.com/gosuri/uitable v0.0.1
 	github.com/hashicorp/go-getter v1.4.2-0.20200106182914-9813cbd4eb02
 	github.com/hashicorp/go-hclog v0.10.1
 	github.com/hashicorp/hcl2 v0.0.0-20191002203319-fb75b3253c80
 	github.com/hashicorp/terraform v0.12.20
+	github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/spf13/cobra v0.0.5
@@ -22,7 +25,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/zclconf/go-cty v1.2.1
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
-	golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e // indirect
+	golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4 // indirect
 	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898
 	helm.sh/helm/v3 v3.0.2
 	k8s.io/api v0.0.0-20191016110408-35e52d86657a

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,8 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZM
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
+github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/garyburd/redigo v1.6.0 h1:0VruCpn7yAIIu7pWVClQC8wxCJEcG3nyzpMSHKi1PQc=
@@ -398,6 +400,8 @@ github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/vault v0.10.4/go.mod h1:KfSyffbKxoVyspOdlaGVjIuwLobi07qD1bAbosPMpP0=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e h1:0aewS5NTyxftZHSnFaJmWE5oCCrj4DyEXkAiMa1iZJM=
+github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.2.0 h1:yPeWdRnmynF7p+lLYz0H2tthW9lqhMJrQV/U7yy4wX0=
@@ -475,6 +479,9 @@ github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
+github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-shellwords v1.0.4/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
@@ -785,9 +792,11 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191028164358-195ce5e7f934/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e h1:9vRrk9YW2BTzLP0VCB9ZDjU4cPqkg+IDWL7XgxA1yxQ=
-golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4 h1:sfkvUWPNGwSV+8/fNqctR5lS2AqCSqYwXdrjCxp/dXo=
+golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/clients/docker_tasks.go
+++ b/pkg/clients/docker_tasks.go
@@ -237,7 +237,15 @@ func (d *DockerTasks) FindContainerIDs(containerName string, typeName config.Res
 
 // RemoveContainer with the given id
 func (d *DockerTasks) RemoveContainer(id string) error {
-	return d.c.ContainerRemove(context.Background(), id, types.ContainerRemoveOptions{Force: true, RemoveVolumes: true})
+	// try and shutdown graceful
+	err := d.c.ContainerRemove(context.Background(), id, types.ContainerRemoveOptions{Force: false, RemoveVolumes: true})
+
+	// unable to shutdown graceful try force
+	if err != nil {
+		return d.c.ContainerRemove(context.Background(), id, types.ContainerRemoveOptions{Force: true, RemoveVolumes: true})
+	}
+
+	return nil
 }
 
 // CreateVolume creates a Docker volume for a cluster

--- a/pkg/clients/docker_tasks_container_remove_test.go
+++ b/pkg/clients/docker_tasks_container_remove_test.go
@@ -1,6 +1,7 @@
 package clients
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -9,13 +10,26 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func TestContainerRemoveCallsRemove(t *testing.T) {
+func TestContainerRemoveCallsRemoveGently(t *testing.T) {
 	md := &mocks.MockDocker{}
 	dt := NewDockerTasks(md, hclog.NewNullLogger())
 
-	md.On("ContainerRemove", mock.Anything, "test", types.ContainerRemoveOptions{Force: true, RemoveVolumes: true}).Return(nil)
+	md.On("ContainerRemove", mock.Anything, "test", types.ContainerRemoveOptions{Force: false, RemoveVolumes: true}).Return(nil)
 
 	dt.RemoveContainer("test")
 
 	md.AssertNumberOfCalls(t, "ContainerRemove", 1)
+}
+
+func TestContainerRemoveFailsCallsRemoveForcefully(t *testing.T) {
+	md := &mocks.MockDocker{}
+	dt := NewDockerTasks(md, hclog.NewNullLogger())
+
+	md.On("ContainerRemove", mock.Anything, "test", types.ContainerRemoveOptions{Force: false, RemoveVolumes: true}).Return(fmt.Errorf("boom"))
+	md.On("ContainerRemove", mock.Anything, "test", types.ContainerRemoveOptions{Force: true, RemoveVolumes: true}).Return(nil)
+
+	dt.RemoveContainer("test")
+	md.AssertCalled(t, "ContainerRemove", mock.Anything, "test", types.ContainerRemoveOptions{Force: true, RemoveVolumes: true})
+
+	md.AssertNumberOfCalls(t, "ContainerRemove", 2)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,12 +18,21 @@ type ResourceType string
 const Applied Status = "applied"
 
 // PendingCreation means the resource has not yet been created
+// it will be created on the next run
 const PendingCreation Status = "pending_creation"
 
-// PendingModification means the resource has been created but is pending an update
+// PendingModification means the resource has been created but
+// if the action is Apply then the resource will be re-created with the next run
+// if the action is Delete then the resource will be removed with the next run
 const PendingModification Status = "pending_modification"
 
+// PendingUpdate means the resource has been requested to be updated
+// if the action is Apply then the resource will be ignored with the next run
+// if the action is Delete then the resrouce will be removed with the next run
+const PendingUpdate Status = "pending_update"
+
 // Failed means the resource failed during creation
+// if the action is Apply the resource will be re-created at the next run
 const Failed Status = "failed"
 
 // Destroyed means the resource has been destroyed

--- a/pkg/config/container.go
+++ b/pkg/config/container.go
@@ -12,13 +12,13 @@ type Container struct {
 
 	Networks []NetworkAttachment `hcl:"network,block" json:"networks,omitempty"` // Attach to the correct network // only when Image is specified
 
-	Image       Image    `hcl:"image,block" json"image"`                   // image to use for the container
-	Command     []string `hcl:"command,optional" json"command,ommitempty"` // command to use when starting the container
-	Environment []KV     `hcl:"env,block" json:"env,omitempty"`            // environment variables to set when starting the container
+	Image       Image    `hcl:"image,block" json:"image"`                  // image to use for the container
+	Command     []string `hcl:"command,optional" json:"command,omitempty"` // command to use when starting the container
+	Environment []KV     `hcl:"env,block" json:"environment,omitempty"`    // environment variables to set when starting the container
 	Volumes     []Volume `hcl:"volume,block" json:"volumes,omitempty"`     // volumes to attach to the container
 	Ports       []Port   `hcl:"port,block" json:"ports,omitempty"`         // ports to expose
 
-	Privileged bool `hcl:"privileged,optional" json"priveleged,omitempty"` // run the container in priviledged mode?
+	Privileged bool `hcl:"privileged,optional" json:"privileged,omitempty"` // run the container in priviledged mode?
 
 	// resource constraints
 	Resources *Resources `hcl:"resources,block" json:"resources,omitempty"` // resource constraints for the container
@@ -50,7 +50,7 @@ type Volume struct {
 
 // KV is a key/value type
 type KV struct {
-	Key   string `hcl:"key" json"key"`
+	Key   string `hcl:"key" json:"key"`
 	Value string `hcl:"value" json:"value"`
 }
 

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -54,14 +54,6 @@ func ParseFolder(folder string, c *Config) error {
 		return err
 	}
 
-	// sub folders
-	filesDir, err := filepath.Glob(path.Join(abs, "**/*.hcl"))
-	if err != nil {
-		return err
-	}
-
-	files = append(files, filesDir...)
-
 	for _, f := range files {
 		err := ParseHCLFile(f, c)
 		if err != nil {

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -56,7 +56,8 @@ func (c *Config) FromJSON(path string) error {
 	return nil
 }
 
-// UnmarshalJSON unmarshals the Config from a JSON string
+// UnmarshalJSON is a cusom Unmarshaler to deal with
+// converting the objects back into their main type
 func (c *Config) UnmarshalJSON(b []byte) error {
 	var objMap map[string]*json.RawMessage
 	err := json.Unmarshal(b, &objMap)
@@ -254,10 +255,13 @@ func (c *Config) Merge(c2 *Config) {
 				// Exists in the collection already
 				// Replace the resource with the new one and set pending state only if it is not marked for modification.
 				// If marked for modification then the user has specifically tained the resource
-				c.Resources[i] = cc2
-				if c.Resources[i].Info().Status != PendingModification {
-					c.Resources[i].Info().Status = PendingUpdate
+				status := c.Resources[i].Info().Status
+				if status != PendingModification {
+					status = PendingUpdate
 				}
+
+				c.Resources[i] = cc2
+				c.Resources[i].Info().Status = status
 
 				found = true
 				break

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -249,10 +249,16 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 func (c *Config) Merge(c2 *Config) {
 	for _, cc2 := range c2.Resources {
 		found := false
-		for _, cc := range c.Resources {
+		for i, cc := range c.Resources {
 			if cc2.Info().Name == cc.Info().Name && cc2.Info().Type == cc.Info().Type {
-				// exists in the collection already set pending state
-				cc.Info().Status = PendingModification
+				// Exists in the collection already
+				// Replace the resource with the new one and set pending state only if it is not marked for modification.
+				// If marked for modification then the user has specifically tained the resource
+				c.Resources[i] = cc2
+				if c.Resources[i].Info().Status != PendingModification {
+					c.Resources[i].Info().Status = PendingUpdate
+				}
+
 				found = true
 				break
 			}

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -256,7 +256,8 @@ func (c *Config) Merge(c2 *Config) {
 				// Replace the resource with the new one and set pending state only if it is not marked for modification.
 				// If marked for modification then the user has specifically tained the resource
 				status := c.Resources[i].Info().Status
-				if status != PendingModification {
+				// do not update the status for resources we need to re-create or have not yet been created
+				if status != PendingModification && status != Failed && status != PendingCreation {
 					status = PendingUpdate
 				}
 

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -257,7 +257,7 @@ func (c *Config) Merge(c2 *Config) {
 				// If marked for modification then the user has specifically tained the resource
 				status := c.Resources[i].Info().Status
 				// do not update the status for resources we need to re-create or have not yet been created
-				if status != PendingModification && status != Failed && status != PendingCreation {
+				if status == Applied {
 					status = PendingUpdate
 				}
 

--- a/pkg/config/state_test.go
+++ b/pkg/config/state_test.go
@@ -86,9 +86,11 @@ func TestConfigMergesAddingItems(t *testing.T) {
 	assert.Len(t, c.Resources, 10)
 }
 
-func TestConfigMergesWithExistingItemSetsPending(t *testing.T) {
+func TestConfigMergesWithExistingItemSetsPendingUpdateWhenApplied(t *testing.T) {
 	c, cleanup := setupConfigTests(t)
 	defer cleanup()
+
+	c.Resources[0].Info().Status = Applied
 
 	c2 := New()
 	c2.AddResource(NewContainer("config"))
@@ -96,5 +98,20 @@ func TestConfigMergesWithExistingItemSetsPending(t *testing.T) {
 	c.Merge(c2)
 
 	assert.Len(t, c.Resources, 9)
-	assert.Equal(t, c.Resources[0].Info().Status, PendingModification)
+	assert.Equal(t, c.Resources[0].Info().Status, PendingUpdate)
+}
+
+func TestConfigMergesWithExistingItemDoesNOTSetsPendingUpdateWhenOtherStatus(t *testing.T) {
+	c, cleanup := setupConfigTests(t)
+	defer cleanup()
+
+	c.Resources[0].Info().Status = PendingCreation
+
+	c2 := New()
+	c2.AddResource(NewContainer("config"))
+
+	c.Merge(c2)
+
+	assert.Len(t, c.Resources, 9)
+	assert.Equal(t, c.Resources[0].Info().Status, PendingCreation)
 }

--- a/pkg/shipyard/engine.go
+++ b/pkg/shipyard/engine.go
@@ -110,6 +110,7 @@ func (e *Engine) Apply(path string) error {
 			(r.Info().Status == config.PendingCreation ||
 				r.Info().Status == config.PendingModification ||
 				r.Info().Status == config.Failed) {
+
 			// get the provider to create the resource
 			p := e.getProvider(r, e.clients)
 			if p == nil {
@@ -147,9 +148,11 @@ func (e *Engine) Apply(path string) error {
 		err = tf.Err()
 	}
 
-	// update the satus of any pending updates
+	// update the status of anything which is pending update as this
+	// is not currently implemented
+	// eventually we should compare resources and update as required
 	for _, i := range e.config.Resources {
-		if i.Info().Status != config.Failed {
+		if i.Info().Status == config.PendingUpdate {
 			i.Info().Status = config.Applied
 		}
 	}


### PR DESCRIPTION
### Introduce taint command and the ability to re-create resources.

Resources can now be tainted using the command `shipyard taint [type] [name]`

When a resource is marked as tained the next run of `shipyard run` will destroy the resource and re-create it.
This feature is especailly useful when building blueprints, often you require a change to a particular container you run `shipyard destroy`
to destroy the stack and then `shipyard run` to re-create. Now it is possible to destroy only the affected resource with `shipyard taint`.

### Change behaviour when processing folders

Previously `shipyard run` would recurse into folders, this behaviour causes problems when the sub-folders contain `*.hcl` files which are not
Shipyard resources. `shipyard run` now only process the top level folder. Sub folder support will be added when we add the `module` feature.

### Improve handling for failed resources

Resources which fail to create can now be retired by re-running `shipyard run`, any depended resources which were not created due to the failure
will also be created when the command is run.