### PR TITLE
Ingress refactor

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
       "env": {},
       "args": [
         "run",
-        "./functional_tests/test_fixtures/single_k3s_cluster"
+        "./functional_tests/test_fixtures/nomad"
       ]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Feature: Docmentation
 2020-02-08T17:03:41.271Z [DEBUG] Attaching container to network: ref=terminal network=wan
     When I run apply                                                   # main_test.go:111 -> iRunApply
     Then there should be 1 network called "wan"                        # main_test.go:149 -> thereShouldBe1NetworkCalled
-    And there should be 1 container running called "docs.wan.shipyard" # main_test.go:115 -> thereShouldBeContainerRunningCalled
+    And there should be 1 container running called "docs.docs.shipyard.run" # main_test.go:115 -> thereShouldBeContainerRunningCalled
     And a call to "http://localhost:8080/" should result in status 200 #
     
 # ...

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 
 	"github.com/shipyard-run/shipyard/pkg/clients"
+	"github.com/shipyard-run/shipyard/pkg/config"
 	"github.com/shipyard-run/shipyard/pkg/shipyard"
 	"github.com/shipyard-run/shipyard/pkg/utils"
 	"github.com/spf13/cobra"
@@ -66,8 +67,14 @@ func newRunCmdFunc(e shipyard.Engine, bp clients.Blueprints, hc clients.HTTP, bc
 			}
 		}
 
+		// have we already got a blueprint in the state
+		blueprintExists := false
+		if bluePrintInState() {
+			blueprintExists = true
+		}
+
 		// Load the files
-		err = e.Apply(dst)
+		res, err := e.Apply(dst)
 		if err != nil {
 			return fmt.Errorf("Unable to apply blueprint: %s", err)
 		}
@@ -78,15 +85,51 @@ func newRunCmdFunc(e shipyard.Engine, bp clients.Blueprints, hc clients.HTTP, bc
 			// do not open the browser windows
 			if *noOpen == false {
 
+				browserList := e.Blueprint().BrowserWindows
+
+				// check if blueprint is in the state, if so do not open these windows again
+				if blueprintExists {
+					browserList = []string{}
+				}
+
+				// check for browser windows in the applied resources
+				for _, r := range res {
+					switch r.Info().Type {
+					case config.TypeContainer:
+						c := r.(*config.Container)
+						for _, p := range c.Ports {
+							if p.Host != "" && p.OpenInBrowser {
+								browserList = append(browserList, fmt.Sprintf("http://localhost:%s", p.Host))
+							}
+						}
+					case config.TypeIngress:
+						c := r.(*config.Ingress)
+						for _, p := range c.Ports {
+							if p.Host != "" && p.OpenInBrowser {
+								browserList = append(browserList, fmt.Sprintf("http://localhost:%s", p.Host))
+							}
+						}
+					case config.TypeDocs:
+						c := r.(*config.Docs)
+						if c.OpenInBrowser {
+							browserList = append(browserList, fmt.Sprintf("http://localhost:%d", c.Port))
+						}
+					}
+				}
+
+				// check the browser windows in the blueprint file
 				wg := sync.WaitGroup{}
 
-				for _, b := range e.Blueprint().BrowserWindows {
+				for _, b := range browserList {
 					wg.Add(1)
 					go func(uri string) {
 						// health check the URL
 						err := hc.HealthCheckHTTP(uri, 30*time.Second)
 						if err == nil {
-							bc.Open(uri)
+							be := bc.Open(uri)
+							if be != nil {
+								l.Error("Unable to open browser", "error", be)
+							}
 						}
 
 						wg.Done()
@@ -94,6 +137,7 @@ func newRunCmdFunc(e shipyard.Engine, bp clients.Blueprints, hc clients.HTTP, bc
 				}
 
 				wg.Wait()
+
 			}
 
 			cmd.Println("")
@@ -115,4 +159,12 @@ func newRunCmdFunc(e shipyard.Engine, bp clients.Blueprints, hc clients.HTTP, bc
 
 		return nil
 	}
+}
+
+func bluePrintInState() bool {
+	//load the state
+	sc := config.New()
+	sc.FromJSON(utils.StatePath())
+
+	return sc.Blueprint != nil
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -109,6 +109,27 @@ func newRunCmdFunc(e shipyard.Engine, bp clients.Blueprints, hc clients.HTTP, bc
 								browserList = append(browserList, fmt.Sprintf("http://localhost:%s", p.Host))
 							}
 						}
+					case config.TypeContainerIngress:
+						c := r.(*config.ContainerIngress)
+						for _, p := range c.Ports {
+							if p.Host != "" && p.OpenInBrowser {
+								browserList = append(browserList, fmt.Sprintf("http://localhost:%s", p.Host))
+							}
+						}
+					case config.TypeNomadIngress:
+						c := r.(*config.NomadIngress)
+						for _, p := range c.Ports {
+							if p.Host != "" && p.OpenInBrowser {
+								browserList = append(browserList, fmt.Sprintf("http://localhost:%s", p.Host))
+							}
+						}
+					case config.TypeK8sIngress:
+						c := r.(*config.K8sIngress)
+						for _, p := range c.Ports {
+							if p.Host != "" && p.OpenInBrowser {
+								browserList = append(browserList, fmt.Sprintf("http://localhost:%s", p.Host))
+							}
+						}
 					case config.TypeDocs:
 						c := r.(*config.Docs)
 						if c.OpenInBrowser {

--- a/functional_tests/features/documentaion.feature
+++ b/functional_tests/features/documentaion.feature
@@ -5,6 +5,6 @@ Feature: Docmentation
 
   Scenario: Documentation
     Given I apply the config "./test_fixtures/docs"
-    And there should be 1 container running called "docs.docs.shipyard"
-    And there should be 1 container running called "terminal.docs.shipyard"
+    And there should be 1 container running called "docs.docs.shipyard.run"
+    And there should be 1 container running called "terminal.docs.shipyard.run"
     And a call to "http://localhost:8080/" should result in status 200

--- a/functional_tests/features/nomad_cluster.feature
+++ b/functional_tests/features/nomad_cluster.feature
@@ -7,4 +7,4 @@ Feature: Nomad Cluster
   Scenario: Nomad Cluster
     Given I apply the config "./test_fixtures/nomad"
     Then there should be 1 network called "cloud"
-    And there should be 1 container running called "server.dev.nomad_cluster.shipyard"
+    And there should be 1 container running called "server.dev.nomad_cluster.shipyard.run"

--- a/functional_tests/features/single_container.feature
+++ b/functional_tests/features/single_container.feature
@@ -5,13 +5,13 @@ Feature: Docker Container
   Scenario: Single Container from Local Blueprint
     Given I apply the config "./test_fixtures/single_container"
     Then there should be 1 network called "onprem"
-    And there should be 1 container running called "consul.container.shipyard"
-    And there should be 1 container running called "consul-http.ingress.shipyard"
+    And there should be 1 container running called "consul.container.shipyard.run"
+    And there should be 1 container running called "consul-http.ingress.shipyard.run"
     And a call to "http://localhost:18500/v1/agent/members" should result in status 200
 
   Scenario: Single Container from Github Blueprint
     Given I apply the config "github.com/shipyard-run/shipyard/functional_tests/test_fixtures//single_container"
     Then there should be 1 network called "onprem"
-    And there should be 1 container running called "consul.container.shipyard"
-    And there should be 1 container running called "consul-http.ingress.shipyard"
+    And there should be 1 container running called "consul.container.shipyard.run"
+    And there should be 1 container running called "consul-http.ingress.shipyard.run"
     And a call to "http://localhost:18500/v1/agent/members" should result in status 200

--- a/functional_tests/features/single_k3s_cluster.feature
+++ b/functional_tests/features/single_k3s_cluster.feature
@@ -6,6 +6,6 @@ Feature: Kubernetes Cluster
   Scenario: K3s Cluster
     Given I apply the config "./test_fixtures/single_k3s_cluster"
     Then there should be 1 network called "cloud"
-    And there should be 1 container running called "server.k3s.k8s_cluster.shipyard"
-    And there should be 1 container running called "consul-http.ingress.shipyard"
+    And there should be 1 container running called "server.k3s.k8s_cluster.shipyard.run"
+    And there should be 1 container running called "consul-http.ingress.shipyard.run"
     And a call to "http://localhost:18500/v1/agent/members" should result in status 200

--- a/functional_tests/test_fixtures/nomad/README.md
+++ b/functional_tests/test_fixtures/nomad/README.md
@@ -1,0 +1,14 @@
+---
+title: Nomad Cluster Example
+author: Nic Jackson
+slug: nomad_cluster
+browser_windows: http://localhost:18500
+---
+
+# Nomad Cluster
+
+This blueprint shows how you can create a Nomad cluser with Consul
+
+```shell
+curl localhost:18500
+```

--- a/functional_tests/test_fixtures/nomad/ingress.hcl
+++ b/functional_tests/test_fixtures/nomad/ingress.hcl
@@ -1,4 +1,4 @@
-ingress "consul-http" {
+container_ingress "consul-http" {
   target  = "container.consul"
 
   port {
@@ -12,8 +12,11 @@ ingress "consul-http" {
   }
 }
 
-ingress "nomad-http" {
-  target  = "nomad_cluster.dev"
+nomad_ingress "nomad-http" {
+  cluster  = "nomad_cluster.dev"
+  job = ""
+  group = ""
+  task = ""
 
   port {
     local  = 4646

--- a/functional_tests/test_fixtures/nomad/ingress.hcl
+++ b/functional_tests/test_fixtures/nomad/ingress.hcl
@@ -6,6 +6,10 @@ ingress "consul-http" {
     remote = 8500
     host   = 18500
   }
+
+  network  {
+    name = "network.cloud"
+  }
 }
 
 ingress "nomad-http" {
@@ -15,5 +19,10 @@ ingress "nomad-http" {
     local  = 4646
     remote = 4646
     host   = 14646
+    open_in_browser = true
+  }
+
+  network  {
+    name = "network.cloud"
   }
 }

--- a/functional_tests/test_fixtures/nomad/nomad.hcl
+++ b/functional_tests/test_fixtures/nomad/nomad.hcl
@@ -13,7 +13,7 @@ nomad_cluster "dev" {
 
   env {
     key = "CONSUL_SERVER"
-    value = "consul.cloud.shipyard"
+    value = "consul.container.shipyard.run"
   }
   
   env {

--- a/functional_tests/test_fixtures/nomad/tools.hcl
+++ b/functional_tests/test_fixtures/nomad/tools.hcl
@@ -17,6 +17,6 @@ container "tools" {
   
   env {
     key = "NOMAD_ADDR"
-    value = "http://server.dev.nomad_cluster.shipyard:4646"
+    value = "http://server.dev.nomad_cluster.shipyard.run:4646"
   }
 }

--- a/functional_tests/test_fixtures/single_container/ingress.hcl
+++ b/functional_tests/test_fixtures/single_container/ingress.hcl
@@ -1,4 +1,4 @@
-ingress "consul-http" {
+container_ingress "consul-http" {
   target  = "container.consul"
 
   network {

--- a/functional_tests/test_fixtures/single_k3s_cluster/ingress.hcl
+++ b/functional_tests/test_fixtures/single_k3s_cluster/ingress.hcl
@@ -1,6 +1,6 @@
-ingress "consul-http" {
-  target = "k8s_cluster.k3s"
-  service  = "svc/consul-consul-server"
+k8s_ingress "consul-http" {
+  cluster = "k8s_cluster.k3s"
+  service  = "consul-consul-server"
 
   network {
     name = "network.cloud"

--- a/pkg/clients/docker_tasks.go
+++ b/pkg/clients/docker_tasks.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"os"
 	gosignal "os/signal"
-	"strconv"
 	"strings"
 	"time"
 
@@ -623,13 +622,13 @@ func createPublishedPorts(ps []config.Port) publishedPorts {
 	}
 
 	for _, p := range ps {
-		dp, _ := nat.NewPort(p.Protocol, strconv.Itoa(p.Local))
+		dp, _ := nat.NewPort(p.Protocol, p.Local)
 		pp.ExposedPorts[dp] = struct{}{}
 
 		pb := []nat.PortBinding{
 			nat.PortBinding{
 				HostIP:   "0.0.0.0",
-				HostPort: strconv.Itoa(p.Host),
+				HostPort: p.Host,
 			},
 		}
 

--- a/pkg/clients/docker_tasks_container_create_test.go
+++ b/pkg/clients/docker_tasks_container_create_test.go
@@ -3,7 +3,6 @@ package clients
 import (
 	"fmt"
 	"io/ioutil"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -35,13 +34,13 @@ var containerConfig = &config.Container{
 	},
 	Ports: []config.Port{
 		config.Port{
-			Local:    8080,
-			Host:     9080,
+			Local:    "8080",
+			Host:     "9080",
 			Protocol: "tcp",
 		},
 		config.Port{
-			Local:    8081,
-			Host:     9081,
+			Local:    "8081",
+			Host:     "9081",
 			Protocol: "udp",
 		},
 	},
@@ -222,21 +221,21 @@ func TestContainerPublishesPorts(t *testing.T) {
 	hc := params[2].(*container.HostConfig)
 
 	// check the first port mapping
-	exp, err := nat.NewPort(cc.Ports[0].Protocol, strconv.Itoa(cc.Ports[0].Local))
+	exp, err := nat.NewPort(cc.Ports[0].Protocol, cc.Ports[0].Local)
 	assert.NoError(t, err)
 	assert.NotNil(t, dc.ExposedPorts[exp])
 
 	// check the port bindings for the local machine
-	assert.Equal(t, strconv.Itoa(cc.Ports[0].Host), hc.PortBindings[exp][0].HostPort)
+	assert.Equal(t, cc.Ports[0].Host, hc.PortBindings[exp][0].HostPort)
 	assert.Equal(t, "0.0.0.0", hc.PortBindings[exp][0].HostIP)
 
 	// check the second port mapping
-	exp, err = nat.NewPort(cc.Ports[1].Protocol, strconv.Itoa(cc.Ports[1].Local))
+	exp, err = nat.NewPort(cc.Ports[1].Protocol, cc.Ports[1].Local)
 	assert.NoError(t, err)
 	assert.NotNil(t, dc.ExposedPorts[exp])
 
 	// check the port bindings for the local machine
-	assert.Equal(t, strconv.Itoa(cc.Ports[1].Host), hc.PortBindings[exp][0].HostPort)
+	assert.Equal(t, cc.Ports[1].Host, hc.PortBindings[exp][0].HostPort)
 	assert.Equal(t, "0.0.0.0", hc.PortBindings[exp][0].HostIP)
 }
 

--- a/pkg/clients/docker_tasks_copy_local_images_test.go
+++ b/pkg/clients/docker_tasks_copy_local_images_test.go
@@ -111,7 +111,7 @@ func TestCopyLocalCopiesArchive(t *testing.T) {
 
 	_, err := dt.CopyLocalDockerImageToVolume(testCopyLocalImages, testCopyLocalVolume)
 	assert.NoError(t, err)
-	mk.AssertCalled(t, "CopyToContainer", mock.Anything, "temp-import.container.shipyard", "/images", mock.Anything, mock.Anything)
+	mk.AssertCalled(t, "CopyToContainer", mock.Anything, "temp-import.container.shipyard.run", "/images", mock.Anything, mock.Anything)
 }
 
 func TestCopyLocalCopiesArchiveFailReturnsError(t *testing.T) {

--- a/pkg/clients/docker_tasks_find_ids_test.go
+++ b/pkg/clients/docker_tasks_find_ids_test.go
@@ -31,7 +31,7 @@ func TestFindContainerIDsReturnsID(t *testing.T) {
 
 	// ensure that the FQDN was passed as an argument
 	args := getCalls(&md.Mock, "ContainerList")[0].Arguments[1].(types.ContainerListOptions)
-	assert.Equal(t, "test.cloud.shipyard", args.Filters.Get("name")[0])
+	assert.Equal(t, "test.cloud.shipyard.run", args.Filters.Get("name")[0])
 
 	// ensure that the id has been returned
 	assert.Len(t, ids, 2)

--- a/pkg/clients/http.go
+++ b/pkg/clients/http.go
@@ -24,8 +24,8 @@ type HTTPImpl struct {
 	l       hclog.Logger
 }
 
-func NewHTTP(d time.Duration, l hclog.Logger) HTTP {
-	return &HTTPImpl{d, l}
+func NewHTTP(backoff time.Duration, l hclog.Logger) HTTP {
+	return &HTTPImpl{backoff, l}
 }
 
 func (h *HTTPImpl) HealthCheckHTTP(address string, timeout time.Duration) error {

--- a/pkg/config/blueprint.go
+++ b/pkg/config/blueprint.go
@@ -7,12 +7,12 @@ import (
 
 // Blueprint defines a stack blueprint for defining yard configs
 type Blueprint struct {
-	Title          string   `hcl:"title,optional"`
-	Author         string   `hcl:"author,optional"`
-	Slug           string   `hcl:"slug,optional"`
-	Intro          string   `hcl:"intro,optional"`
-	BrowserWindows []string `hcl:"browser_windows,optional"`
-	Environment    []KV     `hcl:"env,block"`
+	Title          string   `hcl:"title,optional" json:"title,omitempty"`
+	Author         string   `hcl:"author,optional" json:"author,omitempty"`
+	Slug           string   `hcl:"slug,optional" json:"slug,omitempty"`
+	Intro          string   `hcl:"intro,optional" json:"intro,omitempty"`
+	BrowserWindows []string `hcl:"browser_windows,optional" json:"browser_windows,omitempty"`
+	Environment    []KV     `hcl:"env,block" json:"environment,omitempty"`
 }
 
 // Validate the Blueprint and return errors

--- a/pkg/config/container.go
+++ b/pkg/config/container.go
@@ -25,7 +25,7 @@ type Container struct {
 	Resources *Resources `hcl:"resources,block" json:"resources,omitempty"` // resource constraints for the container
 
 	// health checks for the container
-	HealthCheck *HealthCheck `hcl:"health_check,block"`
+	HealthCheck *HealthCheck `hcl:"health_check,block" json:"health_check,omitempty"`
 }
 
 // NewContainer returns a new Container resource with the correct default options

--- a/pkg/config/container_ingress.go
+++ b/pkg/config/container_ingress.go
@@ -27,6 +27,6 @@ type ContainerIngress struct {
 }
 
 // NewContainerIngress creates a new ingress for standard docker containers with the correct defaults
-func NewContainerIngress(name string) *Ingress {
-	return &Ingress{ResourceInfo: ResourceInfo{Name: name, Type: TypeContainerIngress, Status: PendingCreation}}
+func NewContainerIngress(name string) *ContainerIngress {
+	return &ContainerIngress{ResourceInfo: ResourceInfo{Name: name, Type: TypeContainerIngress, Status: PendingCreation}}
 }

--- a/pkg/config/container_ingress.go
+++ b/pkg/config/container_ingress.go
@@ -1,0 +1,32 @@
+package config
+
+// TypeContainerIngress is the resource string for the type
+const TypeContainerIngress ResourceType = "container_ingress"
+
+// ContainerIngress defines an ingress service mapping ports between local host or docker network and the target
+type ContainerIngress struct {
+	ResourceInfo
+
+	Depends []string `hcl:"depends_on,optional" json:"depends,omitempty"`
+
+	Networks []NetworkAttachment `hcl:"network,block" json:"networks,omitempty"` // Attach to the correct network // only when Image is specified
+
+	// Tartget is the name of the container to attach to "conatiner.[name]"
+	Target string `hcl:"target" json:"target"`
+
+	// Ports to open, an ingress resource can be both a bridge between the host and the
+	// an issolated network resource or bridge between two networks.
+	// For this reason 3 different ports can be specified
+	// Local - The docker network or container port to use for exposing the service, for example an ingress
+	//         with the name consul-ingress configured to point to container.consul could set a local port 18500
+	//         traffic on the same network would be able to reach the consul service on 8500 using the address
+	//         consul-ingress.ingress.shipyard:18500
+	// Remote - This is the destination port for the target container
+	// Host   - The port to expose on localhost, this can be different from the Local container port.
+	Ports []Port `hcl:"port,block" json:"ports,omitempty"`
+}
+
+// NewContainerIngress creates a new ingress for standard docker containers with the correct defaults
+func NewContainerIngress(name string) *Ingress {
+	return &Ingress{ResourceInfo: ResourceInfo{Name: name, Type: TypeContainerIngress, Status: PendingCreation}}
+}

--- a/pkg/config/docs.go
+++ b/pkg/config/docs.go
@@ -14,11 +14,12 @@ type Docs struct {
 
 	Image *Image `hcl:"image,block" json:"image,omitempty"` // image to use for the container
 
-	Path string `hcl:"path" json:"path"`
-	Port int    `hcl:"port" json:"port"`
+	Path          string `hcl:"path" json:"path"`
+	Port          int    `hcl:"port" json:"port"`
+	OpenInBrowser bool   `hcl:"open_in_browser,optional" json:"open_in_browser"`
 
-	IndexTitle string   `hcl:"index_title" json:"index_title"`
-	IndexPages []string `hcl:"index_pages" json:"index_pages,omitempty"`
+	IndexTitle string   `hcl:"index_title,optional" json:"index_title"`
+	IndexPages []string `hcl:"index_pages,optional" json:"index_pages,omitempty"`
 }
 
 // NewDocs creates a new Docs config resource

--- a/pkg/config/healthcheck.go
+++ b/pkg/config/healthcheck.go
@@ -9,10 +9,10 @@ package config
 //    pods     		= ["component=server,app=consul", "component=client,app=consul"] // is the pod running and healthy
 //    nomad_jobs = ["redis"] 																										   // are the Nomad jobs running and healthy
 type HealthCheck struct {
-	Timeout   string   `hcl:"timeout"`
-	HTTP      string   `hcl:"http,optional"`
-	TCP       string   `hcl:"tcp,optional"`
-	Services  []string `hcl:"services,optional"`
-	Pods      []string `hcl:"pods,optional"`
-	NomadJobs []string `hcl:"nomad_jobs,optional"`
+	Timeout   string   `hcl:"timeout" json:"timeout"`
+	HTTP      string   `hcl:"http,optional" json:"http,omitempty"`
+	TCP       string   `hcl:"tcp,optional" json:"tcp,omitempty"`
+	Services  []string `hcl:"services,optional" json:"services,omitempty"`
+	Pods      []string `hcl:"pods,optional" json:"pods,omitempty"`
+	NomadJobs []string `hcl:"nomad_jobs,optional" json:"nomad_jobs,omitempty"`
 }

--- a/pkg/config/helm.go
+++ b/pkg/config/helm.go
@@ -13,7 +13,7 @@ type Helm struct {
 	Chart   string `hcl:"chart"`
 	Values  string `hcl:"values,optional"`
 
-	HealthCheck *HealthCheck `hcl:"health_check,block"`
+	HealthCheck *HealthCheck `hcl:"health_check,block" json:"health_check,omitempty"`
 }
 
 // NewHelm creates a new Helm resource with the correct detaults

--- a/pkg/config/image.go
+++ b/pkg/config/image.go
@@ -3,9 +3,9 @@ package config
 // Image defines a docker image which will be pushed to the clusters Docker
 // registry
 type Image struct {
-	Name string `hcl:"name"`
+	Name string `hcl:"name" json:"name"`
 	// Username is the Docker registry user to use for private repositories
-	Username string `hcl:"username,optional"`
+	Username string `hcl:"username,optional" json:"username,omitempty"`
 	// Password is the Docker registry password to use for private repositories
-	Password string `hcl:"password,optional"`
+	Password string `hcl:"password,optional" json:"password,omitempty"`
 }

--- a/pkg/config/ingress.go
+++ b/pkg/config/ingress.go
@@ -4,6 +4,11 @@ package config
 const TypeIngress ResourceType = "ingress"
 
 // Ingress defines an ingress service mapping ports between local host or docker network and the target
+// Note: This type is Deprecated and will be removed in a later version
+//       Please use one of the new specific types:
+//       * K8sIngress
+//       * NomadIngress
+//       * ContainerIngress
 type Ingress struct {
 	ResourceInfo
 

--- a/pkg/config/k8s_config.go
+++ b/pkg/config/k8s_config.go
@@ -17,7 +17,7 @@ type K8sConfig struct {
 	WaitUntilReady bool `hcl:"wait_until_ready"`
 
 	// HealthCheck defines a health check for the resource
-	HealthCheck *HealthCheck `hcl:"health_check,block"`
+	HealthCheck *HealthCheck `hcl:"health_check,block" json:"health_check,omitempty"`
 }
 
 // NewK8sConfig creates a kubernetes config resource with the correct defaults

--- a/pkg/config/k8s_ingress.go
+++ b/pkg/config/k8s_ingress.go
@@ -1,0 +1,44 @@
+package config
+
+// TypeK8sIngress is the resource string for the type
+const TypeK8sIngress ResourceType = "k8s_ingress"
+
+// K8sIngress defines an ingress service mapping ports between local host or docker network and the target
+type K8sIngress struct {
+	ResourceInfo
+
+	Depends []string `hcl:"depends_on,optional" json:"depends,omitempty"`
+
+	Networks []NetworkAttachment `hcl:"network,block" json:"networks,omitempty"` // Attach to the correct network // only when Image is specified
+
+	// Cluster to connect to
+	Cluster string `hcl:"cluster" json:"cluster"`
+
+	// K8sIngress support the following Kuberentes types
+	// which can be connected to:
+	// * Service
+	// * Deployment
+	// * Pod
+	// Only one option can be specified at any time
+
+	// Service to proxy to.
+	// When proxying to a Kubernetes service, ingress will choose a random
+	// pod within that service.
+	Service string `hcl:"service,optional" json:"service,omitempty"`
+	// Deployment to proxy to.
+	// When proxying to a Kubernetes deployment, ingress will choose a random
+	// pod within that service.
+	Deployment string `hcl:"deployment,optional" json:"deployment,omitempty"`
+	// Pod to proxy to
+	Pod string `hcl:"pod,optional" json:"pod,omitempty"`
+
+	// Namespace is the Kubernetes namespace
+	Namespace string `hcl:"namespace,optional" json:"namespace,omitempty"`
+
+	Ports []Port `hcl:"port,block" json:"ports,omitempty"`
+}
+
+// NewK8sIngress creates a new ingress with the correct defaults
+func NewK8sIngress(name string) *K8sIngress {
+	return &K8sIngress{ResourceInfo: ResourceInfo{Name: name, Type: TypeK8sIngress, Status: PendingCreation}}
+}

--- a/pkg/config/nomad_ingress.go
+++ b/pkg/config/nomad_ingress.go
@@ -1,0 +1,26 @@
+package config
+
+// TypeNomadIngress is the resource string for the type
+const TypeNomadIngress ResourceType = "nomad_ingress"
+
+// NomadIngress defines an ingress service mapping ports between local host or docker network and the target
+type NomadIngress struct {
+	ResourceInfo
+
+	Depends []string `hcl:"depends_on,optional" json:"depends,omitempty"`
+
+	Networks []NetworkAttachment `hcl:"network,block" json:"networks,omitempty"` // Attach to the correct network // only when Image is specified
+
+	Cluster string `hcl:"cluster" json:"cluster"`
+
+	Job   string `hcl:"job" json:"job"`
+	Group string `hcl:"group" json:"group"`
+	Task  string `hcl:"task" json:"task"`
+
+	Ports []Port `hcl:"port,block" json:"ports,omitempty"`
+}
+
+// NewNomadIngress creates a new ingress with the correct defaults
+func NewNomadIngress(name string) *NomadIngress {
+	return &NomadIngress{ResourceInfo: ResourceInfo{Name: name, Type: TypeNomadIngress, Status: PendingCreation}}
+}

--- a/pkg/config/nomad_job.go
+++ b/pkg/config/nomad_job.go
@@ -15,7 +15,7 @@ type NomadJob struct {
 	Paths []string `hcl:"paths" validator:"filepath" json:"paths"`
 
 	// HealthCheck defines a health check for the resource
-	HealthCheck *HealthCheck `hcl:"health_check,block"`
+	HealthCheck *HealthCheck `hcl:"health_check,block" json:"health_check,omitempty"`
 }
 
 // NewNomadJob creates a kubernetes config resource with the correct defaults

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -328,12 +328,22 @@ func ParseReferences(c *Config) error {
 				c.DependsOn = append(c.DependsOn, n.Name)
 			}
 			c.DependsOn = append(c.DependsOn, c.Depends...)
+
+		case TypeContainerIngress:
+			c := r.(*ContainerIngress)
+			for _, n := range c.Networks {
+				c.DependsOn = append(c.DependsOn, n.Name)
+			}
+			c.DependsOn = append(c.DependsOn, c.Target)
+			c.DependsOn = append(c.DependsOn, c.Depends...)
+
 		case TypeDocs:
 			c := r.(*Docs)
 			for _, n := range c.Networks {
 				c.DependsOn = append(c.DependsOn, n.Name)
 			}
 			c.DependsOn = append(c.DependsOn, c.Depends...)
+
 		case TypeExecRemote:
 			c := r.(*ExecRemote)
 			for _, n := range c.Networks {
@@ -346,6 +356,22 @@ func ParseReferences(c *Config) error {
 			if c.Target != "" {
 				c.DependsOn = append(c.DependsOn, c.Target)
 			}
+
+		case TypeIngress:
+			c := r.(*Ingress)
+			for _, n := range c.Networks {
+				c.DependsOn = append(c.DependsOn, n.Name)
+			}
+			c.DependsOn = append(c.DependsOn, c.Target)
+			c.DependsOn = append(c.DependsOn, c.Depends...)
+
+		case TypeK8sCluster:
+			c := r.(*K8sCluster)
+			for _, n := range c.Networks {
+				c.DependsOn = append(c.DependsOn, n.Name)
+			}
+			c.DependsOn = append(c.DependsOn, c.Depends...)
+
 		case TypeHelm:
 			c := r.(*Helm)
 			c.DependsOn = append(c.DependsOn, c.Cluster)
@@ -356,25 +382,29 @@ func ParseReferences(c *Config) error {
 			c.DependsOn = append(c.DependsOn, c.Cluster)
 			c.DependsOn = append(c.DependsOn, c.Depends...)
 
-		case TypeIngress:
-			c := r.(*Ingress)
+		case TypeK8sIngress:
+			c := r.(*K8sIngress)
 			for _, n := range c.Networks {
 				c.DependsOn = append(c.DependsOn, n.Name)
 			}
-			c.DependsOn = append(c.DependsOn, c.Target)
+			c.DependsOn = append(c.DependsOn, c.Cluster)
 			c.DependsOn = append(c.DependsOn, c.Depends...)
-		case TypeK8sCluster:
-			c := r.(*K8sCluster)
-			for _, n := range c.Networks {
-				c.DependsOn = append(c.DependsOn, n.Name)
-			}
-			c.DependsOn = append(c.DependsOn, c.Depends...)
+
 		case TypeNomadCluster:
 			c := r.(*NomadCluster)
 			for _, n := range c.Networks {
 				c.DependsOn = append(c.DependsOn, n.Name)
 			}
 			c.DependsOn = append(c.DependsOn, c.Depends...)
+
+		case TypeNomadIngress:
+			c := r.(*NomadIngress)
+			for _, n := range c.Networks {
+				c.DependsOn = append(c.DependsOn, n.Name)
+			}
+			c.DependsOn = append(c.DependsOn, c.Cluster)
+			c.DependsOn = append(c.DependsOn, c.Depends...)
+
 		case TypeNomadJob:
 			c := r.(*NomadJob)
 			c.DependsOn = append(c.DependsOn, c.Cluster)

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -193,6 +193,29 @@ func ParseHCLFile(file string, c *Config) error {
 
 			c.AddResource(h)
 
+		case string(TypeHelm):
+			h := NewHelm(b.Labels[0])
+
+			err := decodeBody(b, h)
+			if err != nil {
+				return err
+			}
+
+			h.Chart = ensureAbsolute(h.Chart, file)
+			h.Values = ensureAbsolute(h.Values, file)
+
+			c.AddResource(h)
+
+		case string(TypeK8sIngress):
+			i := NewK8sIngress(b.Labels[0])
+
+			err := decodeBody(b, i)
+			if err != nil {
+				return err
+			}
+
+			c.AddResource(i)
+
 		case string(TypeNomadCluster):
 			cl := NewNomadCluster(b.Labels[0])
 
@@ -218,6 +241,16 @@ func ParseHCLFile(file string, c *Config) error {
 
 			c.AddResource(h)
 
+		case string(TypeNomadIngress):
+			i := NewNomadIngress(b.Labels[0])
+
+			err := decodeBody(b, i)
+			if err != nil {
+				return err
+			}
+
+			c.AddResource(i)
+
 		case string(TypeNetwork):
 			n := NewNetwork(b.Labels[0])
 
@@ -227,19 +260,6 @@ func ParseHCLFile(file string, c *Config) error {
 			}
 
 			c.AddResource(n)
-
-		case string(TypeHelm):
-			h := NewHelm(b.Labels[0])
-
-			err := decodeBody(b, h)
-			if err != nil {
-				return err
-			}
-
-			h.Chart = ensureAbsolute(h.Chart, file)
-			h.Values = ensureAbsolute(h.Values, file)
-
-			c.AddResource(h)
 
 		case string(TypeIngress):
 			i := NewIngress(b.Labels[0])
@@ -266,6 +286,16 @@ func ParseHCLFile(file string, c *Config) error {
 			}
 
 			c.AddResource(co)
+
+		case string(TypeContainerIngress):
+			i := NewContainerIngress(b.Labels[0])
+
+			err := decodeBody(b, i)
+			if err != nil {
+				return err
+			}
+
+			c.AddResource(i)
 
 		case string(TypeDocs):
 			do := NewDocs(b.Labels[0])

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -460,6 +460,34 @@ func buildContext() *hcl.EvalContext {
 		},
 	})
 
+	var HomeFunc = function.New(&function.Spec{
+		Params: []function.Parameter{
+			{
+				Name:             "home",
+				Type:             cty.NilType,
+				AllowDynamicType: true,
+			},
+		},
+		Type: function.StaticReturnType(cty.String),
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			return cty.StringVal(utils.HomeFolder()), nil
+		},
+	})
+
+	var ShipyardFunc = function.New(&function.Spec{
+		Params: []function.Parameter{
+			{
+				Name:             "shipyard",
+				Type:             cty.NilType,
+				AllowDynamicType: true,
+			},
+		},
+		Type: function.StaticReturnType(cty.String),
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			return cty.StringVal(utils.ShipyardHome()), nil
+		},
+	})
+
 	var KubeConfigFunc = function.New(&function.Spec{
 		Params: []function.Parameter{
 			{
@@ -480,6 +508,8 @@ func buildContext() *hcl.EvalContext {
 	}
 	ctx.Functions["env"] = EnvFunc
 	ctx.Functions["k8s_config"] = KubeConfigFunc
+	ctx.Functions["home"] = HomeFunc
+	ctx.Functions["shipyard"] = ShipyardFunc
 
 	return ctx
 }

--- a/pkg/config/port.go
+++ b/pkg/config/port.go
@@ -2,8 +2,9 @@ package config
 
 // Port is a port mapping
 type Port struct {
-	Local    int    `hcl:"local" json:"local"`                          // Local port in the container
-	Remote   int    `hcl:"remote" json:"remote"`                        // Remote port of the service
-	Host     int    `hcl:"host,optional" json:"host,omitempty"`         // Host port
-	Protocol string `hcl:"protocol,optional" json:"protocol,omitempty"` // Protocol tcp, udp
+	Local         string `hcl:"local" json:"local"`                              // Local port in the container
+	Remote        string `hcl:"remote" json:"remote"`                            // Remote port of the service
+	Host          string `hcl:"host,optional" json:"host,omitempty"`             // Host port
+	Protocol      string `hcl:"protocol,optional" json:"protocol,omitempty"`     // Protocol tcp, udp
+	OpenInBrowser bool   `hcl:"open_in_browser,optional" json:"open_in_browser"` // When a host port is defined open the location in a browser
 }

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -63,13 +63,14 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	var rawBlueprint *json.RawMessage
-	json.Unmarshal(*objMap["blueprint"], &rawBlueprint)
-
-	bp := &Blueprint{}
-	err = json.Unmarshal(*rawBlueprint, &bp)
-	if err == nil {
-		c.Blueprint = bp
+	if objMap["blueprint"] != nil {
+		var rawBlueprint *json.RawMessage
+		json.Unmarshal(*objMap["blueprint"], &rawBlueprint)
+		bp := &Blueprint{}
+		err = json.Unmarshal(*rawBlueprint, &bp)
+		if err == nil {
+			c.Blueprint = bp
+		}
 	}
 
 	var rawMessagesForResources []*json.RawMessage

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -96,6 +96,24 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 				}
 			}
 			c.AddResource(&t)
+
+		case TypeContainerIngress:
+			t := ContainerIngress{}
+			err := mapstructure.Decode(mm, &t)
+			if err != nil {
+				return err
+			}
+			t.Name = mm["name"].(string)
+			t.Type = ResourceType(mm["type"].(string))
+			t.Status = Status(mm["status"].(string))
+
+			if d, ok := mm["depends_on"].([]interface{}); ok {
+				for _, i := range d {
+					t.DependsOn = append(t.DependsOn, i.(string))
+				}
+			}
+			c.AddResource(&t)
+
 		case TypeDocs:
 			t := Docs{}
 			err := mapstructure.Decode(mm, &t)
@@ -112,6 +130,7 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 				}
 			}
 			c.AddResource(&t)
+
 		case TypeExecRemote:
 			t := ExecRemote{}
 			err := mapstructure.Decode(mm, &t)
@@ -128,6 +147,7 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 				}
 			}
 			c.AddResource(&t)
+
 		case TypeExecLocal:
 			t := ExecLocal{}
 			err := mapstructure.Decode(mm, &t)
@@ -144,6 +164,7 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 				}
 			}
 			c.AddResource(&t)
+
 		case TypeHelm:
 			t := Helm{}
 			err := mapstructure.Decode(mm, &t)
@@ -160,6 +181,7 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 				}
 			}
 			c.AddResource(&t)
+
 		case TypeIngress:
 			t := Ingress{}
 			err := mapstructure.Decode(mm, &t)
@@ -176,6 +198,7 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 				}
 			}
 			c.AddResource(&t)
+
 		case TypeK8sCluster:
 			t := K8sCluster{}
 			err := mapstructure.Decode(mm, &t)
@@ -192,6 +215,7 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 				}
 			}
 			c.AddResource(&t)
+
 		case TypeK8sConfig:
 			t := K8sConfig{}
 			err := mapstructure.Decode(mm, &t)
@@ -208,6 +232,24 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 				}
 			}
 			c.AddResource(&t)
+
+		case TypeK8sIngress:
+			t := K8sIngress{}
+			err := mapstructure.Decode(mm, &t)
+			if err != nil {
+				return err
+			}
+			t.Name = mm["name"].(string)
+			t.Type = ResourceType(mm["type"].(string))
+			t.Status = Status(mm["status"].(string))
+
+			if d, ok := mm["depends_on"].([]interface{}); ok {
+				for _, i := range d {
+					t.DependsOn = append(t.DependsOn, i.(string))
+				}
+			}
+			c.AddResource(&t)
+
 		case TypeNetwork:
 			t := Network{}
 			err := mapstructure.Decode(mm, &t)
@@ -224,6 +266,7 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 				}
 			}
 			c.AddResource(&t)
+
 		case TypeNomadCluster:
 			t := NomadCluster{}
 			err := mapstructure.Decode(mm, &t)
@@ -240,6 +283,7 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 				}
 			}
 			c.AddResource(&t)
+
 		case TypeNomadJob:
 			t := NomadJob{}
 			err := mapstructure.Decode(mm, &t)
@@ -256,6 +300,24 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 				}
 			}
 			c.AddResource(&t)
+
+		case TypeNomadIngress:
+			t := NomadIngress{}
+			err := mapstructure.Decode(mm, &t)
+			if err != nil {
+				return err
+			}
+			t.Name = mm["name"].(string)
+			t.Type = ResourceType(mm["type"].(string))
+			t.Status = Status(mm["status"].(string))
+
+			if d, ok := mm["depends_on"].([]interface{}); ok {
+				for _, i := range d {
+					t.DependsOn = append(t.DependsOn, i.(string))
+				}
+			}
+			c.AddResource(&t)
+
 		}
 	}
 

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -51,9 +51,7 @@ func (c *Config) FromJSON(path string) error {
 	defer f.Close()
 
 	jd := json.NewDecoder(f)
-	jd.Decode(c)
-
-	return nil
+	return jd.Decode(c)
 }
 
 // UnmarshalJSON is a cusom Unmarshaler to deal with
@@ -63,6 +61,15 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 	err := json.Unmarshal(b, &objMap)
 	if err != nil {
 		return err
+	}
+
+	var rawBlueprint *json.RawMessage
+	json.Unmarshal(*objMap["blueprint"], &rawBlueprint)
+
+	bp := &Blueprint{}
+	err = json.Unmarshal(*rawBlueprint, &bp)
+	if err == nil {
+		c.Blueprint = bp
 	}
 
 	var rawMessagesForResources []*json.RawMessage

--- a/pkg/providers/cluster_k3s.go
+++ b/pkg/providers/cluster_k3s.go
@@ -121,8 +121,8 @@ func (c *K8sCluster) createK3s() error {
 	// expose the API server port
 	cc.Ports = []config.Port{
 		config.Port{
-			Local:    apiPort,
-			Host:     apiPort,
+			Local:    fmt.Sprintf("%d", apiPort),
+			Host:     fmt.Sprintf("%d", apiPort),
 			Protocol: "tcp",
 		},
 	}

--- a/pkg/providers/cluster_k3s_test.go
+++ b/pkg/providers/cluster_k3s_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strconv"
 	"testing"
 	"time"
 
@@ -149,13 +148,13 @@ func TestClusterK3CreatesAServer(t *testing.T) {
 	assert.Equal(t, "volume", params.Volumes[0].Type)
 
 	// validate the API port is set
-	assert.GreaterOrEqual(t, params.Ports[0].Local, 64000)
+	assert.GreaterOrEqual(t, params.Ports[0].Local, "64000")
 	assert.GreaterOrEqual(t, params.Ports[0].Local, params.Ports[0].Host)
 	assert.Equal(t, "tcp", params.Ports[0].Protocol)
 
 	// validate the command
 	assert.Equal(t, "server", params.Command[0])
-	assert.Contains(t, params.Command[1], strconv.Itoa(params.Ports[0].Local))
+	assert.Contains(t, params.Command[1], params.Ports[0].Local)
 	assert.Contains(t, params.Command[2], "traefik")
 }
 
@@ -295,7 +294,7 @@ func TestClusterK3sImportDockerCopiesImages(t *testing.T) {
 
 	err := p.Create()
 	assert.NoError(t, err)
-	md.AssertCalled(t, "CopyLocalDockerImageToVolume", []string{"consul:1.6.1", "vault:1.6.1"}, "test.volume.shipyard")
+	md.AssertCalled(t, "CopyLocalDockerImageToVolume", []string{"consul:1.6.1", "vault:1.6.1"}, "test.volume.shipyard.run")
 }
 func TestClusterK3sImportDockerCopyImageFailReturnsError(t *testing.T) {
 	cc, md, mk, cleanup := setupClusterMocks()

--- a/pkg/providers/cluster_nomad.go
+++ b/pkg/providers/cluster_nomad.go
@@ -101,8 +101,8 @@ func (c *NomadCluster) createNomad() error {
 	// expose the API server port
 	cc.Ports = []config.Port{
 		config.Port{
-			Local:    4646,
-			Host:     apiPort,
+			Local:    "4646",
+			Host:     fmt.Sprintf("%d", apiPort),
 			Protocol: "tcp",
 		},
 	}

--- a/pkg/providers/cluster_nomad_test.go
+++ b/pkg/providers/cluster_nomad_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -142,8 +143,10 @@ func TestClusterNomadCreatesAServer(t *testing.T) {
 	assert.Equal(t, "/files", params.Volumes[1].Destination)
 
 	// validate the API port is set
-	assert.GreaterOrEqual(t, params.Ports[0].Local, 4646)
-	assert.GreaterOrEqual(t, params.Ports[0].Host, 64000)
+	intLocal, _ := strconv.Atoi(params.Ports[0].Local)
+	intHost, _ := strconv.Atoi(params.Ports[0].Host)
+	assert.GreaterOrEqual(t, intLocal, 4646)
+	assert.GreaterOrEqual(t, intHost, 64000)
 	assert.Equal(t, "tcp", params.Ports[0].Protocol)
 }
 
@@ -207,7 +210,7 @@ func TestClusterNomadImportDockerCopiesImages(t *testing.T) {
 
 	err := p.Create()
 	assert.NoError(t, err)
-	md.AssertCalled(t, "CopyLocalDockerImageToVolume", []string{"consul:1.6.1", "vault:1.6.1"}, "test.volume.shipyard")
+	md.AssertCalled(t, "CopyLocalDockerImageToVolume", []string{"consul:1.6.1", "vault:1.6.1"}, "test.volume.shipyard.run")
 }
 func TestClusterNomadImportDockerCopyImageFailReturnsError(t *testing.T) {
 	cc, md, mh, cleanup := setupNomadClusterMocks()

--- a/pkg/providers/container.go
+++ b/pkg/providers/container.go
@@ -66,7 +66,7 @@ func (c *Container) Destroy() error {
 			for _, n := range c.config.Networks {
 				err := c.client.DetachNetwork(n.Name, id)
 				if err != nil {
-					return err
+					c.log.Error("Unable to detach network", "ref", c.config.Name, "network", n.Name)
 				}
 			}
 

--- a/pkg/providers/docs.go
+++ b/pkg/providers/docs.go
@@ -86,32 +86,34 @@ func (i *Docs) createDocsContainer() error {
 
 	// if the index pages have been set
 	// generate the javascript
-	indexPath, err := i.generateDocusaursIndex(i.config.IndexTitle, i.config.IndexPages)
-	if err != nil {
-		return xerrors.Errorf("Unable to generate index for documentation: %w", err)
-	}
+	if i.config.IndexTitle != "" && len(i.config.IndexPages) > 0 {
+		indexPath, err := i.generateDocusaursIndex(i.config.IndexTitle, i.config.IndexPages)
+		if err != nil {
+			return xerrors.Errorf("Unable to generate index for documentation: %w", err)
+		}
 
-	cc.Volumes = append(
-		cc.Volumes,
-		config.Volume{
-			Source:      indexPath,
-			Destination: "/shipyard/sidebars.js",
-		},
-	)
+		cc.Volumes = append(
+			cc.Volumes,
+			config.Volume{
+				Source:      indexPath,
+				Destination: "/shipyard/sidebars.js",
+			},
+		)
+	}
 
 	// add the ports
 	cc.Ports = []config.Port{
 		// set the doumentation port
 		config.Port{
-			Local:  80,
-			Remote: 80,
-			Host:   i.config.Port,
+			Local:  "80",
+			Remote: "80",
+			Host:   fmt.Sprintf("%d", i.config.Port),
 		},
 		// set the livereload port
 		config.Port{
-			Local:  37950,
-			Remote: 37950,
-			Host:   37950,
+			Local:  "37950",
+			Remote: "37950",
+			Host:   "37950",
 		},
 	}
 
@@ -146,8 +148,8 @@ func (i *Docs) createTerminalContainer() error {
 	cc.Ports = []config.Port{
 		config.Port{
 			Protocol: "tcp",
-			Host:     27950,
-			Local:    27950,
+			Host:     "27950",
+			Local:    "27950",
 		},
 	}
 

--- a/pkg/providers/docs_test.go
+++ b/pkg/providers/docs_test.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -85,14 +86,14 @@ func TestDocsSetsDocsPorts(t *testing.T) {
 	params := getCalls(&md.Mock, "CreateContainer")[0].Arguments[0].(*config.Container)
 
 	// main port
-	assert.Equal(t, 80, params.Ports[0].Local)
-	assert.Equal(t, 80, params.Ports[0].Remote)
-	assert.Equal(t, d.config.Port, params.Ports[0].Host)
+	assert.Equal(t, "80", params.Ports[0].Local)
+	assert.Equal(t, "80", params.Ports[0].Remote)
+	assert.Equal(t, fmt.Sprintf("%d", d.config.Port), params.Ports[0].Host)
 
 	// livereload
-	assert.Equal(t, 37950, params.Ports[1].Local)
-	assert.Equal(t, 37950, params.Ports[1].Remote)
-	assert.Equal(t, 37950, params.Ports[1].Host)
+	assert.Equal(t, "37950", params.Ports[1].Local)
+	assert.Equal(t, "37950", params.Ports[1].Remote)
+	assert.Equal(t, "37950", params.Ports[1].Host)
 }
 
 func TestDocsPullsTerminalContainer(t *testing.T) {
@@ -128,8 +129,8 @@ func TestDocsSetsTerminalPorts(t *testing.T) {
 	params := getCalls(&md.Mock, "CreateContainer")[1].Arguments[0].(*config.Container)
 
 	// main port
-	assert.Equal(t, 27950, params.Ports[0].Host)
-	assert.Equal(t, 27950, params.Ports[0].Local)
+	assert.Equal(t, "27950", params.Ports[0].Host)
+	assert.Equal(t, "27950", params.Ports[0].Local)
 }
 
 func TestDestroyRemovesContainers(t *testing.T) {

--- a/pkg/providers/ingress.go
+++ b/pkg/providers/ingress.go
@@ -141,7 +141,7 @@ func (i *Ingress) Create() error {
 	// add the ports
 	for _, p := range i.config.Ports {
 		command = append(command, "--ports")
-		command = append(command, fmt.Sprintf("%d:%d", p.Local, p.Remote))
+		command = append(command, fmt.Sprintf("%s:%s", p.Local, p.Remote))
 	}
 
 	// ingress simply crease a container with specific options
@@ -179,7 +179,7 @@ func (i *Ingress) Destroy() error {
 		for _, n := range i.config.Networks {
 			err := i.client.DetachNetwork(n.Name, id)
 			if err != nil {
-				return err
+				i.log.Error("Unable to detach network", "ref", i.config.Name, "network", n.Name)
 			}
 		}
 

--- a/pkg/providers/ingress.go
+++ b/pkg/providers/ingress.go
@@ -35,6 +35,18 @@ func NewContainerIngress(ci *config.ContainerIngress, cc clients.ContainerTasks,
 	return &Ingress{c, cc, l}
 }
 
+// NewNomadIngress creates an ingress type for resources in a Nomad cluster
+func NewNomadIngress(ci *config.NomadIngress, cc clients.ContainerTasks, l hclog.Logger) *Ingress {
+	c := config.NewIngress(ci.Name)
+	c.Depends = ci.Depends
+	c.Networks = ci.Networks
+	c.Target = ci.Cluster
+	c.Ports = ci.Ports
+	c.Config = ci.Config
+
+	return &Ingress{c, cc, l}
+}
+
 // NewK8sIngress creates an Ingress from Kubernetes config
 func NewK8sIngress(kc *config.K8sIngress, cc clients.ContainerTasks, l hclog.Logger) *Ingress {
 	// convert the config

--- a/pkg/providers/ingress_test.go
+++ b/pkg/providers/ingress_test.go
@@ -23,6 +23,7 @@ func testIngressCreateMocks() *mocks.MockContainerTasks {
 	testCluster.Driver = "k3s"
 
 	c := config.New()
+	c.AddResource(&testK8sIngressConfig)
 	c.AddResource(&testIngressConfig)
 	c.AddResource(&testIngressContainerConfig)
 	c.AddResource(testCluster)
@@ -35,7 +36,7 @@ func TestIngressK8sErrorsWhenUnableToLookupIDs(t *testing.T) {
 	md := &mocks.MockContainerTasks{}
 	md.On("FindContainerIDs", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
 
-	p := NewIngress(&testIngressConfig, md, hclog.NewNullLogger())
+	p := NewK8sIngress(&testK8sIngressConfig, md, hclog.NewNullLogger())
 
 	err := p.Create()
 	assert.Error(t, err)
@@ -45,7 +46,7 @@ func TestIngressK8sErrorsWhenClusterExists(t *testing.T) {
 	md := &mocks.MockContainerTasks{}
 	md.On("FindContainerIDs", mock.Anything, mock.Anything).Return([]string{"abc"}, nil)
 
-	p := NewIngress(&testIngressConfig, md, hclog.NewNullLogger())
+	p := NewK8sIngress(&testK8sIngressConfig, md, hclog.NewNullLogger())
 
 	err := p.Create()
 	assert.Error(t, err)
@@ -53,7 +54,7 @@ func TestIngressK8sErrorsWhenClusterExists(t *testing.T) {
 
 func TestIngressK8sTargetPullsImage(t *testing.T) {
 	md := testIngressCreateMocks()
-	p := NewIngress(&testIngressConfig, md, hclog.NewNullLogger())
+	p := NewK8sIngress(&testK8sIngressConfig, md, hclog.NewNullLogger())
 
 	err := p.Create()
 	assert.NoError(t, err)
@@ -62,7 +63,7 @@ func TestIngressK8sTargetPullsImage(t *testing.T) {
 
 func TestIngressK8sTargetConfiguresCommand(t *testing.T) {
 	md := testIngressCreateMocks()
-	p := NewIngress(&testIngressConfig, md, hclog.NewNullLogger())
+	p := NewK8sIngress(&testK8sIngressConfig, md, hclog.NewNullLogger())
 
 	err := p.Create()
 	assert.NoError(t, err)
@@ -82,7 +83,7 @@ func TestIngressK8sTargetConfiguresCommand(t *testing.T) {
 
 func TestIngressK8sTargetConfiguresKubeConfig(t *testing.T) {
 	md := testIngressCreateMocks()
-	p := NewIngress(&testIngressConfig, md, hclog.NewNullLogger())
+	p := NewK8sIngress(&testK8sIngressConfig, md, hclog.NewNullLogger())
 
 	err := p.Create()
 	assert.NoError(t, err)
@@ -100,9 +101,9 @@ func TestIngressK8sTargetConfiguresKubeConfig(t *testing.T) {
 
 func TestIngressK8sTargetWithNamespaceConfiguresCommand(t *testing.T) {
 	md := testIngressCreateMocks()
-	tc := testIngressConfig
+	tc := testK8sIngressConfig
 	tc.Namespace = "mine"
-	p := NewIngress(&tc, md, hclog.NewNullLogger())
+	p := NewK8sIngress(&tc, md, hclog.NewNullLogger())
 
 	err := p.Create()
 	assert.NoError(t, err)
@@ -113,9 +114,56 @@ func TestIngressK8sTargetWithNamespaceConfiguresCommand(t *testing.T) {
 	assert.Equal(t, "mine", params.Command[3])
 }
 
+func TestIngressK8sTargetWithServiceConfiguresCommand(t *testing.T) {
+	md := testIngressCreateMocks()
+	tc := testK8sIngressConfig
+	tc.Service = "myservice"
+	p := NewK8sIngress(&tc, md, hclog.NewNullLogger())
+
+	err := p.Create()
+	assert.NoError(t, err)
+
+	params := getCalls(&md.Mock, "CreateContainer")[0].Arguments[0].(*config.Container)
+
+	// namespace should be same as custom
+	assert.Equal(t, "svc/myservice", params.Command[5])
+}
+
+func TestIngressK8sTargetWithPodConfiguresCommand(t *testing.T) {
+	md := testIngressCreateMocks()
+	tc := testK8sIngressConfig
+	tc.Service = ""
+	tc.Pod = "mypod"
+	p := NewK8sIngress(&tc, md, hclog.NewNullLogger())
+
+	err := p.Create()
+	assert.NoError(t, err)
+
+	params := getCalls(&md.Mock, "CreateContainer")[0].Arguments[0].(*config.Container)
+
+	// namespace should be same as custom
+	assert.Equal(t, "mypod", params.Command[5])
+}
+
+func TestIngressK8sTargetWithDeploymentConfiguresCommand(t *testing.T) {
+	md := testIngressCreateMocks()
+	tc := testK8sIngressConfig
+	tc.Service = ""
+	tc.Deployment = "mydeployment"
+	p := NewK8sIngress(&tc, md, hclog.NewNullLogger())
+
+	err := p.Create()
+	assert.NoError(t, err)
+
+	params := getCalls(&md.Mock, "CreateContainer")[0].Arguments[0].(*config.Container)
+
+	// namespace should be same as custom
+	assert.Equal(t, "deployment/mydeployment", params.Command[5])
+}
+
 func TestIngressContainerTargetConfiguresCommand(t *testing.T) {
 	md := testIngressCreateMocks()
-	p := NewIngress(&testIngressContainerConfig, md, hclog.NewNullLogger())
+	p := NewContainerIngress(&testIngressContainerConfig, md, hclog.NewNullLogger())
 
 	err := p.Create()
 	assert.NoError(t, err)
@@ -128,7 +176,7 @@ func TestIngressContainerTargetConfiguresCommand(t *testing.T) {
 
 func TestIngressContainerAddsPorts(t *testing.T) {
 	md := testIngressCreateMocks()
-	p := NewIngress(&testIngressContainerConfig, md, hclog.NewNullLogger())
+	p := NewContainerIngress(&testIngressContainerConfig, md, hclog.NewNullLogger())
 
 	err := p.Create()
 	assert.NoError(t, err)
@@ -148,7 +196,7 @@ func TestIngressContainerFailReturnsError(t *testing.T) {
 	md := testIngressCreateMocks()
 	removeOn(&md.Mock, "CreateContainer")
 	md.On("CreateContainer", mock.Anything).Return("", fmt.Errorf("boom"))
-	p := NewIngress(&testIngressContainerConfig, md, hclog.NewNullLogger())
+	p := NewContainerIngress(&testIngressContainerConfig, md, hclog.NewNullLogger())
 
 	err := p.Create()
 	assert.Error(t, err)
@@ -175,7 +223,16 @@ var testIngressConfig = config.Ingress{
 	Target:   "k8s_cluster.test",
 }
 
-var testIngressContainerConfig = config.Ingress{
+var testK8sIngressConfig = config.K8sIngress{
+	Service: "web",
+	ResourceInfo: config.ResourceInfo{
+		Name: "web-http",
+	},
+	Networks: []config.NetworkAttachment{config.NetworkAttachment{Name: "cloud"}},
+	Cluster:  "k8s_cluster.test",
+}
+
+var testIngressContainerConfig = config.ContainerIngress{
 	Target: "container.test",
 	Ports: []config.Port{
 		config.Port{

--- a/pkg/providers/ingress_test.go
+++ b/pkg/providers/ingress_test.go
@@ -171,7 +171,7 @@ func TestIngressContainerTargetConfiguresCommand(t *testing.T) {
 	params := getCalls(&md.Mock, "CreateContainer")[0].Arguments[0].(*config.Container)
 
 	assert.Equal(t, "--service-name", params.Command[0])
-	assert.Equal(t, "test.container.shipyard", params.Command[1])
+	assert.Equal(t, "test.container.shipyard.run", params.Command[1])
 }
 
 func TestIngressContainerAddsPorts(t *testing.T) {
@@ -236,14 +236,14 @@ var testIngressContainerConfig = config.ContainerIngress{
 	Target: "container.test",
 	Ports: []config.Port{
 		config.Port{
-			Local:  8080,
-			Remote: 8081,
-			Host:   8082,
+			Local:  "8080",
+			Remote: "8081",
+			Host:   "8082",
 		},
 		config.Port{
-			Local:  9080,
-			Remote: 9081,
-			Host:   9082,
+			Local:  "9080",
+			Remote: "9081",
+			Host:   "9082",
 		},
 	},
 }

--- a/pkg/providers/nomad_job.go
+++ b/pkg/providers/nomad_job.go
@@ -90,12 +90,14 @@ func (n *NomadJob) Destroy() error {
 	_, configPath := utils.CreateNomadConfigPath(cc.Info().Name)
 	err = n.client.SetConfig(configPath)
 	if err != nil {
-		return xerrors.Errorf("Unable to load nomad config %s: %w", configPath, err)
+		n.log.Error("Unable to load Nomad config", "config", configPath, "error", err)
+		return nil
 	}
 
 	err = n.client.Stop(n.config.Paths)
 	if err != nil {
-		return xerrors.Errorf("Unable to create Nomad jobs: %w", err)
+		n.log.Error("Unable to destroy Nomad job", "config", configPath, "error", err)
+		return nil
 	}
 
 	return nil

--- a/pkg/shipyard/engine.go
+++ b/pkg/shipyard/engine.go
@@ -182,10 +182,12 @@ func (e *EngineImpl) Apply(path string) ([]config.Resource, error) {
 
 	if len(e.config.Resources) > 0 {
 		// save the state regardless of error
-		err = e.config.ToJSON(utils.StatePath())
-		if err == nil {
-			return createdResource, err
+		jerr := e.config.ToJSON(utils.StatePath())
+		if jerr != nil {
+			return createdResource, jerr
 		}
+
+		return createdResource, err
 	}
 
 	return nil, tf.Err()

--- a/pkg/shipyard/engine.go
+++ b/pkg/shipyard/engine.go
@@ -345,6 +345,8 @@ func generateProviderImpl(c config.Resource, cc *Clients) providers.Provider {
 		return providers.NewK8sIngress(c.(*config.K8sIngress), cc.ContainerTasks, cc.Logger)
 	case config.TypeNomadCluster:
 		return providers.NewNomadCluster(c.(*config.NomadCluster), cc.ContainerTasks, cc.Nomad, cc.Logger)
+	case config.TypeNomadIngress:
+		return providers.NewNomadIngress(c.(*config.NomadIngress), cc.ContainerTasks, cc.Logger)
 	case config.TypeNomadJob:
 		return providers.NewNomadJob(c.(*config.NomadJob), cc.Nomad, cc.Logger)
 	case config.TypeNetwork:

--- a/pkg/shipyard/engine.go
+++ b/pkg/shipyard/engine.go
@@ -322,6 +322,8 @@ func generateProviderImpl(c config.Resource, cc *Clients) providers.Provider {
 	switch c.Info().Type {
 	case config.TypeContainer:
 		return providers.NewContainer(c.(*config.Container), cc.ContainerTasks, cc.HTTP, cc.Logger)
+	case config.TypeContainerIngress:
+		return providers.NewContainerIngress(c.(*config.ContainerIngress), cc.ContainerTasks, cc.Logger)
 	case config.TypeDocs:
 		return providers.NewDocs(c.(*config.Docs), cc.ContainerTasks, cc.Logger)
 	case config.TypeExecRemote:
@@ -336,6 +338,8 @@ func generateProviderImpl(c config.Resource, cc *Clients) providers.Provider {
 		return providers.NewK8sCluster(c.(*config.K8sCluster), cc.ContainerTasks, cc.Kubernetes, cc.HTTP, cc.Logger)
 	case config.TypeK8sConfig:
 		return providers.NewK8sConfig(c.(*config.K8sConfig), cc.Kubernetes, cc.Logger)
+	case config.TypeK8sIngress:
+		return providers.NewK8sIngress(c.(*config.K8sIngress), cc.ContainerTasks, cc.Logger)
 	case config.TypeNomadCluster:
 		return providers.NewNomadCluster(c.(*config.NomadCluster), cc.ContainerTasks, cc.Nomad, cc.Logger)
 	case config.TypeNomadJob:

--- a/pkg/shipyard/engine_test.go
+++ b/pkg/shipyard/engine_test.go
@@ -106,7 +106,7 @@ func TestApplyCallsProviderInCorrectOrder(t *testing.T) {
 	e, _, mp, cleanup := setupTests(nil)
 	defer cleanup()
 
-	err := e.Apply("../../functional_tests/test_fixtures/single_k3s_cluster")
+	_, err := e.Apply("../../functional_tests/test_fixtures/single_k3s_cluster")
 	assert.NoError(t, err)
 
 	// should have called in order
@@ -122,18 +122,19 @@ func TestApplyCallsProviderCreateForEachProvider(t *testing.T) {
 	e, _, mp, cleanup := setupTests(nil)
 	defer cleanup()
 
-	err := e.Apply("../../functional_tests/test_fixtures/single_k3s_cluster")
+	_, err := e.Apply("../../functional_tests/test_fixtures/single_k3s_cluster")
 	assert.NoError(t, err)
 
 	// should have call create for each provider
 	testAssertMethodCalled(t, mp, "Create", 4)
+	//assert.Len(t, res, 4)
 }
 
 func TestApplyCallsProviderDestroyForResourcesPendingorFailed(t *testing.T) {
 	e, _, mp, cleanup := setupTestsWithState(nil, failedState)
 	defer cleanup()
 
-	err := e.Apply("")
+	_, err := e.Apply("")
 	assert.NoError(t, err)
 
 	// should have call create for each provider
@@ -145,7 +146,7 @@ func TestApplyReturnsErrorWhenProviderDestroyForResourcesPendingorFailed(t *test
 	e, _, mp, cleanup := setupTestsWithState(map[string]error{"dc1": fmt.Errorf("boom")}, failedState)
 	defer cleanup()
 
-	err := e.Apply("")
+	_, err := e.Apply("")
 	assert.Error(t, err)
 
 	// should have call create for each provider
@@ -157,7 +158,7 @@ func TestApplyCallsProviderGenerateErrorStopsExecution(t *testing.T) {
 	e, _, mp, cleanup := setupTests(map[string]error{"cloud": fmt.Errorf("boom")})
 	defer cleanup()
 
-	err := e.Apply("../../functional_tests/test_fixtures/single_k3s_cluster")
+	_, err := e.Apply("../../functional_tests/test_fixtures/single_k3s_cluster")
 	assert.Error(t, err)
 
 	// should have call create for each provider
@@ -168,7 +169,7 @@ func TestApplyCallsProviderCreateErrorStopsExecution(t *testing.T) {
 	e, _, mp, cleanup := setupTests(map[string]error{"cloud": fmt.Errorf("boom")})
 	defer cleanup()
 
-	err := e.Apply("../../functional_tests/test_fixtures/single_k3s_cluster")
+	_, err := e.Apply("../../functional_tests/test_fixtures/single_k3s_cluster")
 	assert.Error(t, err)
 
 	// should have call create for each provider
@@ -179,7 +180,7 @@ func TestApplySetsStatusForEachResource(t *testing.T) {
 	e, _, mp, cleanup := setupTestsWithState(nil, mergedState)
 	defer cleanup()
 
-	err := e.Apply("")
+	_, err := e.Apply("")
 	assert.NoError(t, err)
 
 	// should not call create as this is pending update

--- a/pkg/shipyard/mocks/engine.go
+++ b/pkg/shipyard/mocks/engine.go
@@ -11,10 +11,14 @@ type Engine struct {
 	mock.Mock
 }
 
-func (e *Engine) Apply(path string) error {
+func (e *Engine) Apply(path string) ([]config.Resource, error) {
 	args := e.Called(path)
 
-	return args.Error(0)
+	if r, ok := args.Get(0).([]config.Resource); ok {
+		return r, args.Error(1)
+	}
+
+	return nil, args.Error(1)
 }
 
 func (e *Engine) Destroy(path string, all bool) error {

--- a/pkg/utils/util_test.go
+++ b/pkg/utils/util_test.go
@@ -70,12 +70,17 @@ func TestValidatesNameAndReturnsErrorWhenTooLong(t *testing.T) {
 
 func TestFQDNReturnsCorrectValue(t *testing.T) {
 	fq := FQDN("test", "type")
-	assert.Equal(t, "test.type.shipyard", fq)
+	assert.Equal(t, "test.type.shipyard.run", fq)
+}
+
+func TestFQDNReplacesInvalidChars(t *testing.T) {
+	fq := FQDN("tes&t", "type")
+	assert.Equal(t, "tes-t.type.shipyard.run", fq)
 }
 
 func TestFQDNVolumeReturnsCorrectValue(t *testing.T) {
 	fq := FQDNVolumeName("test")
-	assert.Equal(t, "test.volume.shipyard", fq)
+	assert.Equal(t, "test.volume.shipyard.run", fq)
 }
 
 func TestHomeReturnsCorrectValue(t *testing.T) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -31,15 +31,36 @@ func ValidateName(name string) (bool, error) {
 	return true, nil
 }
 
+func ReplaceNonURIChars(s string) (string, error) {
+	reg, err := regexp.Compile(`[^a-zA-Z0-9\-\.]+`)
+	if err != nil {
+		return "", err
+	}
+
+	return reg.ReplaceAllString(s, "-"), nil
+}
+
 // FQDN generates the full qualified name for a container
 func FQDN(name, typeName string) string {
-	fqdn := fmt.Sprintf("%s.%s.shipyard", name, typeName)
+	// ensure that the name is valid for URI schema
+	cleanName, err := ReplaceNonURIChars(name)
+	if err != nil {
+		panic(err)
+	}
+
+	fqdn := fmt.Sprintf("%s.%s.shipyard.run", cleanName, typeName)
 	return fqdn
 }
 
 // FQDNVolumeName creates a full qualified volume name
 func FQDNVolumeName(name string) string {
-	return fmt.Sprintf("%s.volume.shipyard", name)
+	// ensure that the name is valid for URI schema
+	cleanName, err := ReplaceNonURIChars(name)
+	if err != nil {
+		panic(err)
+	}
+
+	return fmt.Sprintf("%s.volume.shipyard.run", cleanName)
 }
 
 // CreateKubeConfigPath creates the file path for the KubeConfig file when


### PR DESCRIPTION
# Changelog:
* Added ability to open browser windows to ingress, containers, docs
* Defined three specific ingress resources, `nomad_ingress`, `container_ingress`, `k8s_ingress` for now `ingress` is backward compatible
* Only open browser windows if they have not been opened
* Can now do `shipyard run` or `shipyard run .` and this equals `shipyard run ./`
* Sidebar configuration is now optional in docs
* Changed names of Docker resources and FQDN for resources to `[name].[type].shipyard.run`
* Resources are now resolvable via DNS
* Added interpolation helper `${home()}` to resolve the home folder from config
* Added interpolation helper `${shipyard()}` to resolve the shipyard folder from config

Fixes
* Fix serialisation of blueprint in state
* Fix bug with rolled back resources being in an inconsistent state