### PR TITLE
Fix container exec output logs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
       "env": {},
       "args": [
         "run",
-        "./functional_tests/test_fixtures/modules"
+        "./functional_tests/test_fixtures/nomad"
       ]
     },
     {

--- a/pkg/clients/docker_tasks_execute_command_test.go
+++ b/pkg/clients/docker_tasks_execute_command_test.go
@@ -16,13 +16,17 @@ import (
 )
 
 func testExecCommandMockSetup() (*mocks.MockDocker, *mocks.ImageLog) {
+	// we need to add the stream index (stdout) as the first byte for the hijacker
+	writerOutput := []byte("log output")
+	writerOutput = append([]byte{1}, writerOutput...)
+
 	mk := &mocks.MockDocker{}
 	mk.On("ContainerExecCreate", mock.Anything, mock.Anything, mock.Anything).Return(types.IDResponse{ID: "abc"}, nil)
 	mk.On("ContainerExecAttach", mock.Anything, "abc", mock.Anything).Return(
 		types.HijackedResponse{
 			Conn: &net.TCPConn{},
 			Reader: bufio.NewReader(
-				bytes.NewReader([]byte("log output")),
+				bytes.NewReader(writerOutput),
 			),
 		},
 		nil,


### PR DESCRIPTION
This PR fixes badly formatted output logs when executing commands in containers.

#63 