### PR TITLE
Remove color settings for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,23 +5,5 @@
     "**/.settings": true,
     "**/.factorypath": true
   },
-  "workbench.colorCustomizations": {
-    "activityBar.background": "#3399ff",
-    "activityBar.activeBackground": "#3399ff",
-    "activityBar.activeBorder": "#bf0060",
-    "activityBar.foreground": "#15202b",
-    "activityBar.inactiveForeground": "#15202b99",
-    "activityBarBadge.background": "#bf0060",
-    "activityBarBadge.foreground": "#e7e7e7",
-    "titleBar.activeBackground": "#007fff",
-    "titleBar.inactiveBackground": "#007fff99",
-    "titleBar.activeForeground": "#e7e7e7",
-    "titleBar.inactiveForeground": "#e7e7e799",
-    "statusBar.background": "#007fff",
-    "statusBarItem.hoverBackground": "#3399ff",
-    "statusBar.foreground": "#e7e7e7",
-    "statusBar.border": "#007fff",
-    "titleBar.border": "#007fff"
-  },
   "peacock.remoteColor": "#007fff"
 }


### PR DESCRIPTION
Fixes #67. Removes color customisation for vscode to avoid messing up custom themes.