### PR TITLE
fixes typo in comment

### DIFF
--- a/pkg/config/container.go
+++ b/pkg/config/container.go
@@ -19,7 +19,7 @@ type Container struct {
 	Volumes     []Volume `hcl:"volume,block" json:"volumes,omitempty"`           // volumes to attach to the container
 	Ports       []Port   `hcl:"port,block" json:"ports,omitempty"`               // ports to expose
 
-	Privileged bool `hcl:"privileged,optional" json:"privileged,omitempty"` // run the container in priviledged mode?
+	Privileged bool `hcl:"privileged,optional" json:"privileged,omitempty"` // run the container in privileged mode?
 
 	// resource constraints
 	Resources *Resources `hcl:"resources,block" json:"resources,omitempty"` // resource constraints for the container

--- a/pkg/config/sidecar.go
+++ b/pkg/config/sidecar.go
@@ -18,7 +18,7 @@ type Sidecar struct {
 	Environment []KV     `hcl:"env,block" json:"environment,omitempty"`          // environment variables to set when starting the container
 	Volumes     []Volume `hcl:"volume,block" json:"volumes,omitempty"`           // volumes to attach to the container
 
-	Privileged bool `hcl:"privileged,optional" json:"privileged,omitempty"` // run the container in priviledged mode?
+	Privileged bool `hcl:"privileged,optional" json:"privileged,omitempty"` // run the container in privileged mode?
 
 	// resource constraints
 	Resources *Resources `hcl:"resources,block" json:"resources,omitempty"` // resource constraints for the container


### PR DESCRIPTION
Came across this misspelling in two places - one in this repo, one in `shipyard-website` (in an example).

Fixing it here so it is consistent.