### PR TITLE
adds missing dot in example resource identifier

### DIFF
--- a/cmd/taint.go
+++ b/cmd/taint.go
@@ -11,7 +11,7 @@ import (
 
 var taintCmd = &cobra.Command{
 	Use:   "taint [type].[name]",
-	Short: "Taint a resource e.g. 'shipyard taint container test'",
+	Short: "Taint a resource e.g. 'shipyard taint container.test'",
 	Long: `Taint a resource and mark is to be re-created on the next Apply
 	Example use to remove a container named test
 	shipyard taint container.test


### PR DESCRIPTION
Hello maintainers 👋 

This minimal change fixes a help text bit that was missing a dot to be correct.