### PR TITLE
Set random port range for clusters

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## version v0.3.1
 
+* Set max random ports for clusters to 64000
+
+## version v0.3.1
 ### Image Caching
 
 To save bandwidth all containers launched from Kubernetes and Nomad clusters are cached by Shipyard. Currently images

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -316,15 +316,20 @@ func (cr *CucumberRunner) thereShouldBeAResourceRunningCalled(resource string, n
 			return err
 		}
 
-		if len(cl) == 1 {
+		runningCount := 0
+		for _, c := range cl {
 			// check to see if the container has failed
-			if cl[0].State == "exited" {
+			if c.State == "exited" {
 				return fmt.Errorf("container exited prematurely")
 			}
 
-			if cl[0].State == "running" {
-				return nil
+			if c.State == "running" {
+				runningCount++
 			}
+		}
+
+		if runningCount == len(cl) {
+			return nil
 		}
 
 		// wait a few seconds before trying again

--- a/examples/nomad/output.hcl
+++ b/examples/nomad/output.hcl
@@ -1,3 +1,3 @@
 output "NOMAD_HTTP_ADDR" {
-  value = cluster_api("dev")
+  value = cluster_api("nomad_cluster.dev")
 }

--- a/pkg/clients/mocks/nomad.go
+++ b/pkg/clients/mocks/nomad.go
@@ -3,6 +3,7 @@ package mocks
 import (
 	"time"
 
+	"github.com/shipyard-run/shipyard/pkg/utils"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -10,7 +11,7 @@ type MockNomad struct {
 	mock.Mock
 }
 
-func (m *MockNomad) SetConfig(c string, ctx string) error {
+func (m *MockNomad) SetConfig(c utils.ClusterConfig, ctx string) error {
 	args := m.Called(c, ctx)
 
 	return args.Error(0)

--- a/pkg/clients/nomad.go
+++ b/pkg/clients/nomad.go
@@ -73,7 +73,6 @@ func (n *NomadImpl) HealthCheckAPI(timeout time.Duration) error {
 	n.l.Debug("Performing Nomad health check", "address", address)
 	st := time.Now()
 	for {
-		fmt.Println("ok")
 		if time.Now().Sub(st) > timeout {
 			n.l.Error("Timeout wating for Nomad healthcheck", "address", address)
 

--- a/pkg/clients/nomad_test.go
+++ b/pkg/clients/nomad_test.go
@@ -400,6 +400,36 @@ func TestNomadEndpointsReturnsTwoEndpoints(t *testing.T) {
 	assert.Equal(t, "10.5.0.3:19090", e[1]["http"])
 }
 
+func TestNomadEndpointsReturnsConnectEndpoints(t *testing.T) {
+	fp, _, mh := setupNomadTests(t)
+
+	removeOn(&mh.Mock, "Do")
+	mh.On("Do", mock.Anything, mock.Anything, mock.Anything).Return(
+		&http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(jobAllocationsConnectResponse))),
+		},
+		nil,
+	).Once()
+
+	mh.On("Do", mock.Anything, mock.Anything, mock.Anything).Return(
+		&http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(allocationsConnectResponse))),
+		},
+		nil,
+	).Once()
+
+	c := NewNomad(mh, 1*time.Millisecond, hclog.NewNullLogger())
+	c.SetConfig(fp, "local")
+
+	e, err := c.Endpoints("web", "web", "web")
+	assert.NoError(t, err)
+	assert.Len(t, e, 1)
+
+	assert.Equal(t, "10.5.0.4:9090", e[0]["http"])
+}
+
 var aliveResponse = `
 [
 	{
@@ -636,5 +666,246 @@ var allocationsResponse2 = `
       }
     ]
   }
+}
+`
+
+var jobAllocationsConnectResponse = `
+[
+  {
+    "ID": "da975cd1-8b04-6bce-9d5c-03e47353768c",
+  	"EvalID": "02ee5334-be8f-fcba-41a0-cbbae8e34fce",
+    "Name": "example_1.fake_service[0]",
+    "Namespace": "default",
+    "NodeID": "e92cfe74-1ba3-2248-cf89-18760af8c278",
+    "NodeName": "server.dev",
+    "JobID": "example_1",
+    "JobType": "service",
+    "JobVersion": 0,
+    "TaskGroup": "fake_service",
+    "DesiredStatus": "run",
+    "DesiredDescription": "",
+    "ClientStatus": "running"
+  }
+]
+`
+var allocationsConnectResponse = `
+{
+  "ID": "c64cec54-843a-b660-c8ff-386bcaaaef88",
+  "Namespace": "default",
+  "EvalID": "02ee5334-be8f-fcba-41a0-cbbae8e34fce",
+  "Name": "web.web[0]",
+  "NodeID": "fd7e30b8-80e6-5cb0-980e-01913a8c6666",
+  "NodeName": "server.local",
+  "JobID": "web",
+  "Job": {
+    "Stop": false,
+    "Region": "global",
+    "Namespace": "default",
+    "ID": "web",
+    "ParentID": "",
+    "Name": "web",
+    "Type": "service",
+    "Priority": 50,
+    "AllAtOnce": false,
+    "Datacenters": [
+      "dc1"
+    ],
+    "Constraints": null,
+    "Affinities": null,
+    "Spreads": null,
+    "TaskGroups": [
+      {
+        "Name": "web",
+        "Count": 1,
+        "Tasks": [
+          {
+            "Name": "web",
+            "Driver": "docker",
+            "User": "",
+            "Config": {
+              "image": "nicholasjackson/fake-service:v0.9.0"
+            }
+          },
+          {
+            "Name": "connect-proxy-web",
+            "Driver": "docker",
+            "User": ""
+          }
+        ],
+        "Networks": [
+          {
+            "Mode": "bridge",
+            "Device": "",
+            "CIDR": "",
+            "IP": "",
+            "MBits": 10,
+            "ReservedPorts": [
+              {
+                "Label": "http",
+                "Value": 9090,
+                "To": 9090
+              }
+            ],
+            "DynamicPorts": [
+              {
+                "Label": "connect-proxy-web",
+                "Value": 0,
+                "To": -1
+              }
+            ]
+          }
+        ],
+        "Services": [
+          {
+            "Name": "web",
+            "PortLabel": "9090",
+            "AddressMode": "auto",
+            "EnableTagOverride": false,
+            "Tags": [
+              "global",
+              "app"
+            ],
+            "CanaryTags": null,
+            "Checks": null,
+            "Connect": {
+            },
+            "Meta": null,
+            "CanaryMeta": null
+          }
+        ],
+        "Volumes": null,
+        "ShutdownDelay": null
+      }
+    ]
+  },
+  "TaskGroup": "web",
+  "Resources": {
+    "CPU": 750,
+    "MemoryMB": 384,
+    "Networks": [
+      {
+        "Mode": "bridge",
+        "Device": "eth0",
+        "IP": "10.5.0.4",
+        "ReservedPorts": [
+          {
+            "Label": "http",
+            "Value": 9090,
+            "To": 9090
+          }
+        ],
+        "DynamicPorts": [
+          {
+            "Label": "connect-proxy-web",
+            "Value": 27144,
+            "To": 27144
+          }
+        ]
+      }
+    ],
+    "Devices": null
+  },
+  "SharedResources": {
+    "CPU": 0,
+    "MemoryMB": 0,
+    "DiskMB": 30,
+    "IOPS": 0,
+    "Networks": [
+      {
+        "Mode": "bridge",
+        "Device": "eth0",
+        "CIDR": "",
+        "IP": "10.5.0.4",
+        "MBits": 10,
+        "ReservedPorts": [
+          {
+            "Label": "http",
+            "Value": 9090,
+            "To": 9090
+          }
+        ],
+        "DynamicPorts": [
+          {
+            "Label": "connect-proxy-web",
+            "Value": 27144,
+            "To": 27144
+          }
+        ]
+      }
+    ],
+    "Devices": null
+  },
+  "AllocatedResources": {
+    "Tasks": {
+      "web": {
+        "Cpu": {
+          "CpuShares": 500
+        },
+        "Memory": {
+          "MemoryMB": 256
+        },
+        "Networks": null,
+        "Devices": null
+      },
+      "connect-proxy-web": {
+        "Cpu": {
+          "CpuShares": 250
+        },
+        "Memory": {
+          "MemoryMB": 128
+        },
+        "Networks": null,
+        "Devices": null
+      }
+    },
+    "TaskLifecycles": {
+      "web": null,
+      "connect-proxy-web": {
+        "Hook": "prestart",
+        "Sidecar": true
+      }
+    },
+    "Shared": {
+      "Networks": [
+        {
+          "Mode": "bridge",
+          "Device": "eth0",
+          "CIDR": "",
+          "IP": "10.5.0.4",
+          "MBits": 10,
+          "ReservedPorts": [
+            {
+              "Label": "http",
+              "Value": 9090,
+              "To": 9090
+            }
+          ],
+          "DynamicPorts": [
+            {
+              "Label": "connect-proxy-web",
+              "Value": 27144,
+              "To": 27144
+            }
+          ]
+        }
+      ],
+      "DiskMB": 30
+    }
+  },
+  "DesiredStatus": "run",
+  "ClientStatus": "running",
+  "ClientDescription": "Tasks are running",
+  "DeploymentID": "8154fd6a-830c-117d-3a48-b9c1454507c0",
+  "DeploymentStatus": {
+    "Healthy": true,
+    "Timestamp": "2021-03-22T07:20:45.5071198Z",
+    "Canary": false,
+    "ModifyIndex": 42
+  },
+  "CreateIndex": 15,
+  "ModifyIndex": 42,
+  "AllocModifyIndex": 15,
+  "CreateTime": 1616397620428715000,
+  "ModifyTime": 1616397645647263000
 }
 `

--- a/pkg/config/blueprint_test.go
+++ b/pkg/config/blueprint_test.go
@@ -11,7 +11,7 @@ func setupBlueprints(t *testing.T, contents string) (*Config, func()) {
 	createNamedFile(t, dir, "*.yard", contents)
 
 	c := &Config{}
-	err := ParseFolder(dir, c, false, nil, "")
+	err := ParseFolder(dir, c, false, "", []string{}, nil, "")
 	assert.NoError(t, err)
 
 	return c, cleanup

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -205,6 +205,7 @@ func (c *Config) DoYaLikeDAGs() (*dag.AcyclicGraph, error) {
 
 	// Loop over all resources and add to dag
 	for _, resource := range c.Resources {
+		//fmt.Printf("Resource: %s, Type: %s\n", resource.Info().Name, resource.Info().Type)
 		graph.Add(resource)
 	}
 

--- a/pkg/config/exec_remote_test.go
+++ b/pkg/config/exec_remote_test.go
@@ -12,7 +12,7 @@ func setupTestConfig(t *testing.T, contents string) (*Config, string, func()) {
 	createNamedFile(t, dir, "*.hcl", contents)
 
 	c := New()
-	err := ParseFolder(dir, c, false, nil, "")
+	err := ParseFolder(dir, c, false, "", []string{}, nil, "")
 	assert.NoError(t, err)
 
 	err = ParseReferences(c)

--- a/pkg/config/parse_test.go
+++ b/pkg/config/parse_test.go
@@ -25,7 +25,7 @@ func TestRunParsesBlueprintInMarkdownFormat(t *testing.T) {
 	}
 
 	c := New()
-	err = ParseFolder(absoluteFolderPath, c, false, nil, "")
+	err = ParseFolder(absoluteFolderPath, c, false, "", []string{}, nil, "")
 	assert.NoError(t, err)
 
 	assert.NotNil(t, c.Blueprint)
@@ -47,7 +47,7 @@ func TestRunParsesBlueprintInHCLFormat(t *testing.T) {
 	}
 
 	c := New()
-	err = ParseFolder(absoluteFolderPath, c, false, nil, "")
+	err = ParseFolder(absoluteFolderPath, c, false, "", []string{}, nil, "")
 	assert.NoError(t, err)
 
 	assert.NotNil(t, c.Blueprint)
@@ -58,7 +58,7 @@ func TestLoadsVariablesFiles(t *testing.T) {
 	assert.NoError(t, err)
 
 	c := New()
-	err = ParseFolder(absoluteFolderPath, c, false, nil, "")
+	err = ParseFolder(absoluteFolderPath, c, false, "", []string{}, nil, "")
 	assert.NoError(t, err)
 
 	// check variable has been interpolated
@@ -85,7 +85,7 @@ func TestLoadsVariablesFromOptionalFile(t *testing.T) {
 	assert.NoError(t, err)
 
 	c := New()
-	err = ParseFolder(absoluteFolderPath, c, false, nil, absoluteVarsPath)
+	err = ParseFolder(absoluteFolderPath, c, false, "", []string{}, nil, absoluteVarsPath)
 	assert.NoError(t, err)
 
 	// check variable has been interpolated
@@ -111,7 +111,7 @@ func TestOverridesVariablesFilesWithFlag(t *testing.T) {
 	}
 
 	c := New()
-	err = ParseFolder(absoluteFolderPath, c, false, map[string]string{"something": "else"}, "")
+	err = ParseFolder(absoluteFolderPath, c, false, "", []string{}, map[string]string{"something": "else"}, "")
 	assert.NoError(t, err)
 
 	// check variable has been interpolated
@@ -142,7 +142,7 @@ func TestOverridesVariablesFilesWithEnv(t *testing.T) {
 	})
 
 	c := New()
-	err = ParseFolder(absoluteFolderPath, c, false, nil, "")
+	err = ParseFolder(absoluteFolderPath, c, false, "", []string{}, nil, "")
 	assert.NoError(t, err)
 
 	// check variable has been interpolated
@@ -168,7 +168,7 @@ func TestVariablesSetFromDefault(t *testing.T) {
 	}
 
 	c := New()
-	err = ParseFolder(absoluteFolderPath, c, false, nil, "")
+	err = ParseFolder(absoluteFolderPath, c, false, "", []string{}, nil, "")
 	assert.NoError(t, err)
 
 	// check variable has been interpolated
@@ -192,7 +192,7 @@ func TestOverridesVariableDefaultsWithEnv(t *testing.T) {
 	})
 
 	c := New()
-	err = ParseFolder(absoluteFolderPath, c, false, nil, "")
+	err = ParseFolder(absoluteFolderPath, c, false, "", []string{}, nil, "")
 	assert.NoError(t, err)
 
 	// check variable has been interpolated
@@ -210,7 +210,7 @@ func TestVariablesSetFromDefaultModule(t *testing.T) {
 	}
 
 	c := New()
-	err = ParseFolder(absoluteFolderPath, c, false, nil, "")
+	err = ParseFolder(absoluteFolderPath, c, false, "", []string{}, nil, "")
 	assert.NoError(t, err)
 
 	// check variable has been interpolated
@@ -234,7 +234,7 @@ func TestOverridesVariablesSetFromDefaultModuleWithEnv(t *testing.T) {
 	})
 
 	c := New()
-	err = ParseFolder(absoluteFolderPath, c, false, nil, "")
+	err = ParseFolder(absoluteFolderPath, c, false, "", []string{}, nil, "")
 	assert.NoError(t, err)
 
 	// check variable has been interpolated
@@ -252,7 +252,7 @@ func TestDoesNotLoadsVariablesFilesFromInsideModules(t *testing.T) {
 	}
 
 	c := New()
-	err = ParseFolder(absoluteFolderPath, c, false, nil, "")
+	err = ParseFolder(absoluteFolderPath, c, false, "", []string{}, nil, "")
 	assert.NoError(t, err)
 
 	// check variable has been interpolated
@@ -279,7 +279,7 @@ func TestParseModuleCreatesResources(t *testing.T) {
 	}
 
 	c := New()
-	err = ParseFolder(absoluteFolderPath, c, false, nil, "")
+	err = ParseFolder(absoluteFolderPath, c, false, "", []string{}, nil, "")
 	assert.NoError(t, err)
 
 	// count the resources, should create 10
@@ -303,7 +303,7 @@ func TestParseFileFunctionReadCorrectly(t *testing.T) {
 	}
 
 	c := New()
-	err = ParseFolder(absoluteFolderPath, c, false, nil, "")
+	err = ParseFolder(absoluteFolderPath, c, false, "", []string{}, nil, "")
 	assert.NoError(t, err)
 
 	// check variable has been interpolated
@@ -330,7 +330,7 @@ func TestParseAddsCacheDependencyToK8sResources(t *testing.T) {
 
 	c := New()
 
-	err = ParseFolder(absoluteFolderPath, c, false, nil, "")
+	err = ParseFolder(absoluteFolderPath, c, false, "", []string{}, nil, "")
 	assert.NoError(t, err)
 
 	err = ParseReferences(c)
@@ -351,7 +351,7 @@ func TestParseAddsCacheDependencyToNomadResources(t *testing.T) {
 
 	c := New()
 
-	err = ParseFolder(absoluteFolderPath, c, false, nil, "")
+	err = ParseFolder(absoluteFolderPath, c, false, "", []string{}, nil, "")
 	assert.NoError(t, err)
 
 	err = ParseReferences(c)

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -434,7 +434,7 @@ func ParseHCLFile(file string, c *Config, moduleName string, dependsOn []string)
 	}
 
 	for _, b := range body.Blocks {
-		fmt.Printf("Parsing: %s, type: %s\n", file, b.Type)
+		//fmt.Printf("Parsing: %s, type: %s\n", file, b.Type)
 
 		switch b.Type {
 		case string(TypeVariable):
@@ -1027,15 +1027,9 @@ func buildContext() *hcl.EvalContext {
 		},
 		Type: function.StaticReturnType(cty.String),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-			_, configPath := utils.CreateClusterConfigPath(args[0].AsString())
-			conf := utils.ClusterConfig{}
-			err := conf.Load(configPath, utils.LocalContext)
+			conf, _ := utils.GetClusterConfig(args[0].AsString())
 
-			if err != nil {
-				return cty.StringVal(""), nil
-			}
-
-			return cty.StringVal(conf.APIAddress()), nil
+			return cty.StringVal(conf.APIAddress(utils.LocalContext)), nil
 		},
 	})
 

--- a/pkg/providers/cluster_k3s.go
+++ b/pkg/providers/cluster_k3s.go
@@ -161,8 +161,8 @@ func (c *K8sCluster) createK3s() error {
 		cc.EnvVar[k] = v
 	}
 
-	// set the API server port to a random number 64000 - 65000
-	apiPort := rand.Intn(1000) + 64000
+	// set the API server port to a random number
+	apiPort := rand.Intn(utils.MaxRandomPort-utils.MinRandomPort) + utils.MinRandomPort
 	connectorPort := rand.Intn(2767) + 30000
 	args := []string{"server", fmt.Sprintf("--https-listen-port=%d", apiPort)}
 

--- a/pkg/providers/cluster_k3s_test.go
+++ b/pkg/providers/cluster_k3s_test.go
@@ -217,8 +217,9 @@ func TestClusterK3CreatesAServer(t *testing.T) {
 	// validate the API port is set
 	localPort, _ := strconv.Atoi(params.Ports[0].Local)
 	hostPort, _ := strconv.Atoi(params.Ports[0].Host)
-	assert.GreaterOrEqual(t, localPort, 64000)
-	assert.GreaterOrEqual(t, hostPort, 64000)
+	assert.GreaterOrEqual(t, localPort, utils.MinRandomPort)
+	assert.LessOrEqual(t, localPort, utils.MaxRandomPort)
+	assert.Equal(t, hostPort, localPort)
 	assert.Equal(t, "tcp", params.Ports[0].Protocol)
 
 	localPort, _ = strconv.Atoi(params.Ports[1].Local)

--- a/pkg/providers/cluster_k3s_test.go
+++ b/pkg/providers/cluster_k3s_test.go
@@ -567,6 +567,22 @@ func TestClusterK3sDestroyRemovesContainer(t *testing.T) {
 	md.AssertCalled(t, "RemoveContainer", mock.Anything)
 }
 
+func TestClusterK3sDestroyRemovesConfig(t *testing.T) {
+	cc, md, mk, mc := setupClusterMocks(t)
+	removeOn(&md.Mock, "FindContainerIDs")
+	md.On("FindContainerIDs", mock.Anything, mock.Anything).Return([]string{"found"}, nil)
+
+	_, dir := utils.GetClusterConfig(string(cc.Info().Type) + "." + cc.Info().Name)
+
+	p := NewK8sCluster(cc, md, mk, nil, mc, hclog.NewNullLogger())
+
+	err := p.Destroy()
+	assert.NoError(t, err)
+	md.AssertCalled(t, "RemoveContainer", mock.Anything)
+
+	assert.NoDirExists(t, dir)
+}
+
 func TestLookupReturnsIDs(t *testing.T) {
 	cc, md, mk, mc := setupClusterMocks(t)
 	p := NewK8sCluster(cc, md, mk, nil, mc, hclog.NewNullLogger())

--- a/pkg/providers/cluster_nomad.go
+++ b/pkg/providers/cluster_nomad.go
@@ -409,7 +409,6 @@ func (c *NomadCluster) ImportLocalDockerImages(name string, id string, images []
 	// execute the command to import the image
 	// write any command output to the logger
 	for _, i := range imagesFile {
-		fmt.Println(i)
 		err = c.client.ExecuteCommand(id, []string{"docker", "load", "-i", i}, nil, "/", c.log.StandardWriter(&hclog.StandardLoggerOptions{ForceLevel: hclog.Debug}))
 		if err != nil {
 			return err

--- a/pkg/providers/cluster_nomad.go
+++ b/pkg/providers/cluster_nomad.go
@@ -200,8 +200,8 @@ func (c *NomadCluster) createNomad() error {
 
 func (c *NomadCluster) createServerNode(image, volumeID string, isClient bool) (string, string, string, error) {
 	// set the API server port to a random number 64000 - 65000
-	apiPort := rand.Intn(1000) + 64000
-	connectorPort := rand.Intn(1000) + 64000
+	apiPort := rand.Intn(utils.MaxRandomPort-utils.MinRandomPort) + utils.MinRandomPort
+	connectorPort := rand.Intn(utils.MaxRandomPort-utils.MinRandomPort) + utils.MinRandomPort
 
 	// if the node count is 0 we are creating a combo client server
 	nodeCount := 1

--- a/pkg/providers/cluster_nomad.go
+++ b/pkg/providers/cluster_nomad.go
@@ -344,7 +344,7 @@ func (c *NomadCluster) createClientNode(index int, image, volumeID, configDir, s
 
 func (c *NomadCluster) appendProxyEnv(cc *config.Container) error {
 	// only add the variables for the cache when the kubernetes version is >= v1.18.16
-	sv, err := semver.NewConstraint(">= v0.12.8")
+	sv, err := semver.NewConstraint(">= v0.11.8")
 	if err != nil {
 		// Handle constraint not being parsable.
 		return err
@@ -352,7 +352,7 @@ func (c *NomadCluster) appendProxyEnv(cc *config.Container) error {
 
 	v, err := semver.NewVersion(c.config.Version)
 	if err != nil {
-		return fmt.Errorf("Kubernetes version is not valid semantic version: %s", err)
+		return fmt.Errorf("Nomad version is not valid semantic version: %s", err)
 	}
 
 	if sv.Check(v) {

--- a/pkg/providers/cluster_nomad.go
+++ b/pkg/providers/cluster_nomad.go
@@ -17,7 +17,7 @@ import (
 )
 
 const nomadBaseImage = "shipyardrun/nomad"
-const nomadBaseVersion = "v0.12.8"
+const nomadBaseVersion = "v0.11.8"
 
 const dataDir = `
 data_dir = "/etc/nomad.d/data"

--- a/pkg/providers/cluster_nomad_test.go
+++ b/pkg/providers/cluster_nomad_test.go
@@ -359,7 +359,7 @@ func TestClusterNomadSetsEnvironmentOnServer(t *testing.T) {
 
 func TestClusterNomadDoesNotSetProxyEnvironmentWithWrongVersion(t *testing.T) {
 	cc, md, mh := setupNomadClusterMocks(t)
-	cc.Version = "v0.12.1"
+	cc.Version = "v0.11.7"
 	cc.ClientNodes = 1
 
 	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())

--- a/pkg/providers/cluster_nomad_test.go
+++ b/pkg/providers/cluster_nomad_test.go
@@ -175,14 +175,16 @@ func TestClusterNomadCreatesAServer(t *testing.T) {
 	intLocal, _ := strconv.Atoi(params.Ports[0].Local)
 	intHost, _ := strconv.Atoi(params.Ports[0].Host)
 	assert.GreaterOrEqual(t, intLocal, 4646)
-	assert.GreaterOrEqual(t, intHost, 64000)
+	assert.GreaterOrEqual(t, intHost, utils.MinRandomPort)
+	assert.LessOrEqual(t, intHost, utils.MaxRandomPort)
 	assert.Equal(t, "tcp", params.Ports[0].Protocol)
 
 	// validate the Connector port is set
 	intLocal, _ = strconv.Atoi(params.Ports[1].Local)
 	intHost, _ = strconv.Atoi(params.Ports[1].Host)
 	assert.GreaterOrEqual(t, intLocal, 19090)
-	assert.GreaterOrEqual(t, intHost, 64000)
+	assert.GreaterOrEqual(t, intHost, utils.MinRandomPort)
+	assert.LessOrEqual(t, intHost, utils.MaxRandomPort)
 	assert.Equal(t, "tcp", params.Ports[0].Protocol)
 }
 

--- a/pkg/providers/legacy_ingress.go
+++ b/pkg/providers/legacy_ingress.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
-const ingressImage = "shipyardrun/ingress:latest"
+const ingressImage = "shipyardrun/ingress:v0.3.0"
 
 // Ingress defines a provider for handling connection ingress for a cluster
 type LegacyIngress struct {

--- a/pkg/providers/legacy_ingress.go
+++ b/pkg/providers/legacy_ingress.go
@@ -122,7 +122,7 @@ func (i *LegacyIngress) Create() error {
 		// make sure that the proxy runs in nomad mode
 		serviceName = i.config.Service
 		_, nomadConfigPath := utils.GetClusterConfig(string(config.TypeNomadCluster) + "." + v.Name)
-		nomadConfigDestPath := "/.nomad/config.json"
+		nomadConfigDestPath := "/.nomad/"
 
 		volumes = append(volumes, config.Volume{
 			Source:      nomadConfigPath,

--- a/pkg/providers/legacy_ingress.go
+++ b/pkg/providers/legacy_ingress.go
@@ -121,7 +121,7 @@ func (i *LegacyIngress) Create() error {
 		// if this is a nomad cluster we need to add the nomadconfig and
 		// make sure that the proxy runs in nomad mode
 		serviceName = i.config.Service
-		_, nomadConfigPath := utils.CreateClusterConfigPath(v.Name)
+		_, nomadConfigPath := utils.GetClusterConfig(string(config.TypeNomadCluster) + "." + v.Name)
 		nomadConfigDestPath := "/.nomad/config.json"
 
 		volumes = append(volumes, config.Volume{

--- a/pkg/providers/legacy_ingress_test.go
+++ b/pkg/providers/legacy_ingress_test.go
@@ -266,7 +266,7 @@ func TestIngressNomadTargetConfiguresNomadConfig(t *testing.T) {
 	// check the volume mount is set
 	_, path := utils.GetClusterConfig(string(config.TypeNomadCluster) + "." + "test")
 	assert.Equal(t, path, params.Volumes[0].Source)
-	assert.Equal(t, "/.nomad/config.json", params.Volumes[0].Destination)
+	assert.Equal(t, "/.nomad/", params.Volumes[0].Destination)
 }
 
 func TestIngressNomadTargetConfiguresCommand(t *testing.T) {

--- a/pkg/providers/legacy_ingress_test.go
+++ b/pkg/providers/legacy_ingress_test.go
@@ -264,7 +264,7 @@ func TestIngressNomadTargetConfiguresNomadConfig(t *testing.T) {
 	params := getCalls(&md.Mock, "CreateContainer")[0].Arguments[0].(*config.Container)
 
 	// check the volume mount is set
-	_, path := utils.CreateClusterConfigPath("test")
+	_, path := utils.GetClusterConfig(string(config.TypeNomadCluster) + "." + "test")
 	assert.Equal(t, path, params.Volumes[0].Source)
 	assert.Equal(t, "/.nomad/config.json", params.Volumes[0].Destination)
 }

--- a/pkg/providers/nomad_job.go
+++ b/pkg/providers/nomad_job.go
@@ -78,13 +78,13 @@ func (n *NomadJob) Destroy() error {
 	n.log.Info("Destroy Nomad Job", "ref", n.config.Name)
 
 	// find the cluster
-	cc, err := n.config.ResourceInfo.FindDependentResource(n.config.Cluster)
+	_, err := n.config.ResourceInfo.FindDependentResource(n.config.Cluster)
 	if err != nil {
 		return err
 	}
 
 	// load the config
-	clusterConfig, _ := utils.GetClusterConfig(cc.Info().Name)
+	clusterConfig, _ := utils.GetClusterConfig(n.config.Cluster)
 	n.client.SetConfig(clusterConfig, string(utils.LocalContext))
 
 	err = n.client.Stop(n.config.Paths)

--- a/pkg/providers/nomad_job.go
+++ b/pkg/providers/nomad_job.go
@@ -34,11 +34,8 @@ func (n *NomadJob) Create() error {
 	}
 
 	// load the config
-	_, configPath := utils.CreateClusterConfigPath(cc.Info().Name)
-	err = n.client.SetConfig(configPath, string(utils.LocalContext))
-	if err != nil {
-		return xerrors.Errorf("Unable to load nomad config %s: %w", configPath, err)
-	}
+	clusterConfig, _ := utils.GetClusterConfig(string(cc.Info().Type) + "." + cc.Info().Name)
+	n.client.SetConfig(clusterConfig, string(utils.LocalContext))
 
 	err = n.client.Create(n.config.Paths)
 	if err != nil {
@@ -87,16 +84,12 @@ func (n *NomadJob) Destroy() error {
 	}
 
 	// load the config
-	_, configPath := utils.CreateClusterConfigPath(cc.Info().Name)
-	err = n.client.SetConfig(configPath, string(utils.LocalContext))
-	if err != nil {
-		n.log.Error("Unable to load Nomad config", "config", configPath, "error", err)
-		return nil
-	}
+	clusterConfig, _ := utils.GetClusterConfig(cc.Info().Name)
+	n.client.SetConfig(clusterConfig, string(utils.LocalContext))
 
 	err = n.client.Stop(n.config.Paths)
 	if err != nil {
-		n.log.Error("Unable to destroy Nomad job", "config", configPath, "error", err)
+		n.log.Error("Unable to destroy Nomad job", "error", err)
 		return nil
 	}
 

--- a/pkg/providers/template.go
+++ b/pkg/providers/template.go
@@ -32,6 +32,19 @@ func (c *Template) Create() error {
 		return fmt.Errorf("Template source empty")
 	}
 
+	if c.config.Vars == nil || len(c.config.Vars) == 0 {
+		// no variables just write the file
+		f, err := os.Create(c.config.Destination)
+		if err != nil {
+			return fmt.Errorf("Unable to create destination file for template: %s", err)
+		}
+		defer f.Close()
+
+		_, err = f.WriteString(c.config.Source)
+
+		return err
+	}
+
 	tmpl := template.New("template").Delims("#{{", "}}")
 
 	t, err := tmpl.Parse(c.config.Source)

--- a/pkg/providers/template_test.go
+++ b/pkg/providers/template_test.go
@@ -46,6 +46,19 @@ func TestTemplateProcessesCorrectly(t *testing.T) {
 	assert.Contains(t, string(d), `data_dir = "something"`)
 }
 
+func TestTemplateWriteSourceWhenNoVars(t *testing.T) {
+	tmpl, provider := setupTemplate(t)
+	provider.config.Vars = nil
+
+	err := provider.Create()
+	assert.NoError(t, err)
+
+	d, err := ioutil.ReadFile(tmpl.Destination)
+	assert.NoError(t, err)
+
+	assert.Contains(t, string(d), `data_dir = "#{{ .Vars.data_dir }}"`)
+}
+
 func TestTemplateOverwritesExistingFile(t *testing.T) {
 	tmpl, provider := setupTemplate(t)
 

--- a/pkg/shipyard/engine.go
+++ b/pkg/shipyard/engine.go
@@ -375,7 +375,7 @@ func (e *EngineImpl) readConfig(path string, variables map[string]string, variab
 				return nil, err
 			}
 		} else {
-			err := config.ParseFolder(path, cc, false, variables, variablesFile)
+			err := config.ParseFolder(path, cc, false, "", []string{}, variables, variablesFile)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/utils/cluster_config.go
+++ b/pkg/utils/cluster_config.go
@@ -42,13 +42,11 @@ const LocalContext Context = "local"
 const RemoteContext Context = "remote"
 
 // Load the config from a file
-func (n *ClusterConfig) Load(file string, context Context) error {
+func (n *ClusterConfig) Load(file string) error {
 	f, err := os.Open(file)
 	if err != nil {
 		return err
 	}
-
-	n.context = context
 
 	return json.NewDecoder(f).Decode(n)
 }
@@ -74,13 +72,13 @@ func (n *ClusterConfig) Save(file string) error {
 }
 
 // APIAddress returns the FQDN for the API server
-func (n *ClusterConfig) APIAddress() string {
+func (n *ClusterConfig) APIAddress(context Context) string {
 	protocol := "http"
 	if n.SSL {
 		protocol = "https"
 	}
 
-	if n.context == LocalContext {
+	if context == LocalContext {
 		return fmt.Sprintf("%s://%s:%d", protocol, n.LocalAddress, n.APIPort)
 	}
 
@@ -88,8 +86,8 @@ func (n *ClusterConfig) APIAddress() string {
 }
 
 // ConnectorAddress returns the FQDN for the gRPC endpoing of the Connector
-func (n *ClusterConfig) ConnectorAddress() string {
-	if n.context == LocalContext {
+func (n *ClusterConfig) ConnectorAddress(context Context) string {
+	if context == LocalContext {
 		return fmt.Sprintf("%s:%d", n.LocalAddress, n.ConnectorPort)
 	}
 

--- a/pkg/utils/cluster_config_test.go
+++ b/pkg/utils/cluster_config_test.go
@@ -33,7 +33,7 @@ func TestConfigLoadsCorrectly(t *testing.T) {
 	fp := setupNomadTests(t)
 
 	nc := &ClusterConfig{}
-	err := nc.Load(fp, "local")
+	err := nc.Load(fp)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "localhost", nc.LocalAddress)
@@ -42,7 +42,7 @@ func TestConfigLoadsCorrectly(t *testing.T) {
 
 func TestNomadConfigLoadReturnsErrorWhenFileNotExist(t *testing.T) {
 	nc := &ClusterConfig{}
-	err := nc.Load("file.json", "local")
+	err := nc.Load("file.json")
 	assert.Error(t, err)
 }
 
@@ -60,7 +60,7 @@ func TestConfiSavesFile(t *testing.T) {
 
 	// check the old file was deleted and the new file was written
 	nc2 := &ClusterConfig{}
-	err = nc2.Load(fp, LocalContext)
+	err = nc2.Load(fp)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "nomad", nc2.LocalAddress)
@@ -68,25 +68,25 @@ func TestConfiSavesFile(t *testing.T) {
 }
 
 func TestConfigReturnsAPIFQDN(t *testing.T) {
-	nc := ClusterConfig{LocalAddress: "localhost", APIPort: 4646, context: LocalContext}
+	nc := ClusterConfig{LocalAddress: "localhost", APIPort: 4646}
 
-	assert.Equal(t, "http://localhost:4646", nc.APIAddress())
+	assert.Equal(t, "http://localhost:4646", nc.APIAddress(LocalContext))
 }
 
 func TestConfigReturnsLocalAPIFQDNSSL(t *testing.T) {
-	nc := ClusterConfig{LocalAddress: "localhost", APIPort: 4646, SSL: true, context: LocalContext}
+	nc := ClusterConfig{LocalAddress: "localhost", APIPort: 4646, SSL: true}
 
-	assert.Equal(t, "https://localhost:4646", nc.APIAddress())
+	assert.Equal(t, "https://localhost:4646", nc.APIAddress(LocalContext))
 }
 
 func TestConfigReturnsRemoteAPIFQDNSSL(t *testing.T) {
-	nc := ClusterConfig{LocalAddress: "localhost", RemoteAddress: "nomad.remote", APIPort: 4646, RemoteAPIPort: 4646, SSL: true, context: RemoteContext}
+	nc := ClusterConfig{LocalAddress: "localhost", RemoteAddress: "nomad.remote", APIPort: 4646, RemoteAPIPort: 4646, SSL: true}
 
-	assert.Equal(t, "https://nomad.remote:4646", nc.APIAddress())
+	assert.Equal(t, "https://nomad.remote:4646", nc.APIAddress(RemoteContext))
 }
 
 func TestConfigReturnsConnectorFQDN(t *testing.T) {
-	nc := ClusterConfig{LocalAddress: "localhost", ConnectorPort: 4646, context: LocalContext}
+	nc := ClusterConfig{LocalAddress: "localhost", ConnectorPort: 4646}
 
-	assert.Equal(t, "localhost:4646", nc.ConnectorAddress())
+	assert.Equal(t, "localhost:4646", nc.ConnectorAddress(LocalContext))
 }

--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -17,3 +17,6 @@ const ProxyAddress string = "http://docker-cache.container.shipyard.run:3128"
 
 // Addresses to bypass when using a HTTP Proxy
 const ProxyBypass string = "localhost,127.0.0.1,cluster.local,shipyard.run,svc,consul"
+
+const MaxRandomPort = 64000
+const MinRandomPort = 60000

--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -18,5 +18,5 @@ const ProxyAddress string = "http://docker-cache.container.shipyard.run:3128"
 // Addresses to bypass when using a HTTP Proxy
 const ProxyBypass string = "localhost,127.0.0.1,cluster.local,shipyard.run,svc,consul"
 
-const MaxRandomPort = 50000
-const MinRandomPort = 40000
+const MaxRandomPort = 32767
+const MinRandomPort = 30000

--- a/pkg/utils/consts.go
+++ b/pkg/utils/consts.go
@@ -18,5 +18,5 @@ const ProxyAddress string = "http://docker-cache.container.shipyard.run:3128"
 // Addresses to bypass when using a HTTP Proxy
 const ProxyBypass string = "localhost,127.0.0.1,cluster.local,shipyard.run,svc,consul"
 
-const MaxRandomPort = 64000
-const MinRandomPort = 60000
+const MaxRandomPort = 50000
+const MinRandomPort = 40000


### PR DESCRIPTION
The latest windows or docker for windows updates seems to have issues with ports over 64000. Nomad and Consul clusters use a random port +60000 for the API, this has now been restricted to a max of 64000.