### PR TITLE
Fix bug where parsers context is not cleared,

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,7 +24,9 @@
       "request": "launch",
       "mode": "debug",
       "program": "${workspaceFolder}",
-      "env": {},
+      "env": {
+        "LOG_LEVEL": "debug"
+      },
       "args": [
         "destroy",
       ]
@@ -35,7 +37,9 @@
       "request": "launch",
       "mode": "debug",
       "program": "${workspaceFolder}",
-      "env": {},
+      "env": {
+        "LOG_LEVEL": "debug"
+      },
       "args": [
         "push",
         "nicholasjackson/example-wasm-filter:latest",
@@ -47,11 +51,13 @@
       "type": "go",
       "request": "launch",
       "mode": "debug",
-      "program": "${workspaceFolder}/main.go",
-      "env": {},
+      "program": "${workspaceFolder}",
+      "env": {
+        "LOG_LEVEL": "debug"
+      },
       "args": [
         "test",
-        "./examples/container",
+        "/home/nicj/go/src/github.com/shipyard-run/blueprints/modules/kubernetes-consul",
       ]
     }
   ]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,9 +23,9 @@ var engine shipyard.Engine
 var logger hclog.Logger
 var engineClients *shipyard.Clients
 
-var version string
-var date string
-var commit string
+var version string // set by build process
+var date string    // set by build process
+var commit string  // set by build process
 
 func init() {
 	var vm gvm.Versions
@@ -33,7 +33,7 @@ func init() {
 	// setup dependencies
 	logger = createLogger()
 	engine, vm = createEngine(logger)
-	engineClients := engine.GetClients()
+	engineClients = engine.GetClients()
 
 	//cobra.OnInitialize(configure)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -179,10 +179,12 @@ func newRunCmdFunc(e shipyard.Engine, bp clients.Getter, hc clients.HTTP, bc cli
 
 		// update status every 30s to let people know we are still running
 		statusUpdate := time.NewTicker(15 * time.Second)
+		startTime := time.Now()
 
 		go func() {
-			for _ = range statusUpdate.C {
-				logger.Info("Please wait, still creating resources ...")
+			for range statusUpdate.C {
+				elapsedTime := time.Now().Sub(startTime).String()
+				logger.Info("Please wait, still creating resources [Elapsed Time: " + elapsedTime + "]")
 			}
 		}()
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -67,6 +67,9 @@ var statusCmd = &cobra.Command{
 				case config.Failed:
 					status = fmt.Sprintf(Red, "FAILED")
 					failedCount++
+				case config.Disabled:
+					status = fmt.Sprintf(Teal, "DISABLED")
+					failedCount++
 				default:
 					pendingCount++
 				}

--- a/pkg/providers/template.go
+++ b/pkg/providers/template.go
@@ -40,6 +40,7 @@ func (c *Template) Create() error {
 		}
 		defer f.Close()
 
+		c.log.Debug("Template output", "ref", c.config.Name, "destination", c.config.Source)
 		_, err = f.WriteString(c.config.Source)
 
 		return err
@@ -77,6 +78,8 @@ func (c *Template) Create() error {
 	defer f.Close()
 
 	f.WriteString(bs.String())
+
+	c.log.Debug("Template output", "ref", c.config.Name, "destination", bs.String())
 
 	return nil
 }

--- a/pkg/shipyard/engine.go
+++ b/pkg/shipyard/engine.go
@@ -173,7 +173,6 @@ func (e *EngineImpl) ApplyWithVariables(path string, vars map[string]string, var
 	}
 
 	if variablesFile != "" {
-
 		variablesFile, err = filepath.Abs(variablesFile)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This causes problems with the test command when running multiple scenarios with `shipyard test`. The context that holds the variables was being created on `init()`, this is fine when the process exits before the next run but with test, the process exists for multiple runs, and variables from a previous run were polluting the current run.