### PR TITLE
Add env unset

### DIFF
--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -80,3 +80,4 @@ var envState = `
   ]
 }
 `
+

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -48,6 +48,20 @@ func TestSetsEnvironmentVariables(t *testing.T) {
 	assert.Contains(t, `export apples="pears"`, out.String())
 }
 
+func TestUnsetsEnvironmentVariables(t *testing.T) {
+	en := setupEnvState(t, envState)
+	en.Flags().Set("unset", "true")
+	out := bytes.NewBufferString("")
+	en.SetOutput(out)
+
+	err := en.Execute()
+	assert.NoError(t, err)
+
+	assert.Contains(t, `unset foo`, out.String())
+	assert.Contains(t, `unset abc`, out.String())
+	assert.Contains(t, `unset apples`, out.String())
+}
+
 var envState = `
 {
   "blueprint": {


### PR DESCRIPTION
Adds --unset flag to the shipyard env
    - add unit test for --unest flag
    - add help text for both unix base and windows
    - add flag to return os appropriate commands to unset shipyard env vars