### PR TITLE
Fix bug where containers were not stopped gracefully

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,7 @@
       },
       "args": [
         "run",
-        "./examples/single_k3s_cluster"
+        "/home/nicj/go/src/github.com/hashicorp/service-based-networking/consul-vms/users-1"
       ]
     },    {
       "name": "Debug - Destroy",
@@ -29,6 +29,7 @@
       },
       "args": [
         "destroy",
+        "/home/nicj/go/src/github.com/hashicorp/service-based-networking/consul-vms/users-1"
       ]
     },
     {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -176,7 +176,7 @@ func createK8sShell(r config.Resource, dt clients.ContainerTasks, pod, container
 	if err != nil {
 		return fmt.Errorf("Could not create exec container. Error: %s", err)
 	}
-	defer dt.RemoveContainer(tools)
+	defer dt.RemoveContainer(tools, true)
 
 	in, stdout, _ := term.StdStreams()
 	err = dt.CreateShell(tools, append(exec, command...), in, stdout, stdout)

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -49,7 +49,7 @@ func setupExec(state string) (*cobra.Command, *mocks.MockContainerTasks, func())
 	mt.On("FindContainerIDs", mock.Anything, mock.Anything).Return([]string{"abc"}, nil)
 	mt.On("CreateShell", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mt.On("CreateContainer", mock.Anything).Return("123", nil)
-	mt.On("RemoveContainer", mock.Anything).Return(nil)
+	mt.On("RemoveContainer", mock.Anything, mock.Anything).Return(nil)
 	mt.On("PullImage", config.Image{Name: "shipyardrun/ingress:latest"}, false).Return(nil)
 
 	return newExecCmd(mt), mt, setupState(state)
@@ -190,7 +190,7 @@ func TestExecK8sCallsRemove(t *testing.T) {
 	err := c.Execute()
 	assert.NoError(t, err)
 
-	mt.AssertCalled(t, "RemoveContainer", mock.Anything)
+	mt.AssertCalled(t, "RemoveContainer", mock.Anything, true)
 }
 
 func TestExecCreatesShellInCluster(t *testing.T) {

--- a/pkg/clients/container_tasks.go
+++ b/pkg/clients/container_tasks.go
@@ -24,7 +24,7 @@ type ContainerTasks interface {
 	// returns error when unable to read info such as when the container does not exist.
 	ContainerInfo(id string) (interface{}, error)
 	// RemoveContainer stops and removes a running container
-	RemoveContainer(id string) error
+	RemoveContainer(id string, force bool) error
 	// BuildContainer builds a container based on the given configuration
 	// If a cahced image already exists Build will noop
 	// When force is specificed BuildContainer will rebuild the container regardless of cached images

--- a/pkg/clients/docker_tasks_container_create_test.go
+++ b/pkg/clients/docker_tasks_container_create_test.go
@@ -103,6 +103,7 @@ func setupContainerMocks() (*clients.MockDocker, *clients.ImageLog) {
 	md.On("ContainerCreate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(container.ContainerCreateCreatedBody{ID: "test"}, nil)
 	md.On("ContainerStart", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	md.On("ContainerStop", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	md.On("ContainerRemove", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	md.On("NetworkConnect", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	md.On("NetworkDisconnect", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)

--- a/pkg/clients/docker_tasks_container_remove_test.go
+++ b/pkg/clients/docker_tasks_container_remove_test.go
@@ -17,10 +17,41 @@ func TestContainerRemoveCallsRemoveGently(t *testing.T) {
 	dt := NewDockerTasks(md, mic, &TarGz{}, hclog.NewNullLogger())
 
 	md.On("ContainerRemove", mock.Anything, "test", types.ContainerRemoveOptions{Force: false, RemoveVolumes: true}).Return(nil)
+	md.On("ContainerStop", mock.Anything, "test", mock.Anything).Return(nil)
 
-	dt.RemoveContainer("test")
+	dt.RemoveContainer("test", false)
 
+	md.AssertNumberOfCalls(t, "ContainerStop", 1)
 	md.AssertNumberOfCalls(t, "ContainerRemove", 1)
+}
+
+func TestContainerRemoveCallsRemoveGentlyOnStopFailForces(t *testing.T) {
+	md := &mocks.MockDocker{}
+	mic := &clients.ImageLog{}
+	dt := NewDockerTasks(md, mic, &TarGz{}, hclog.NewNullLogger())
+
+	md.On("ContainerStop", mock.Anything, "test", mock.Anything).Return(fmt.Errorf("boom"))
+	md.On("ContainerRemove", mock.Anything, "test", types.ContainerRemoveOptions{Force: true, RemoveVolumes: true}).Return(nil)
+
+	dt.RemoveContainer("test", false)
+
+	md.AssertNumberOfCalls(t, "ContainerStop", 1)
+	md.AssertNumberOfCalls(t, "ContainerRemove", 1)
+}
+
+func TestContainerRemoveCallsRemoveGentlyOnRemoveFailForces(t *testing.T) {
+	md := &mocks.MockDocker{}
+	mic := &clients.ImageLog{}
+	dt := NewDockerTasks(md, mic, &TarGz{}, hclog.NewNullLogger())
+
+	md.On("ContainerStop", mock.Anything, "test", mock.Anything).Return(nil)
+	md.On("ContainerRemove", mock.Anything, "test", types.ContainerRemoveOptions{Force: false, RemoveVolumes: true}).Return(fmt.Errorf("boom"))
+	md.On("ContainerRemove", mock.Anything, "test", types.ContainerRemoveOptions{Force: true, RemoveVolumes: true}).Return(nil)
+
+	dt.RemoveContainer("test", false)
+
+	md.AssertNumberOfCalls(t, "ContainerStop", 1)
+	md.AssertNumberOfCalls(t, "ContainerRemove", 2)
 }
 
 func TestContainerRemoveFailsCallsRemoveForcefully(t *testing.T) {
@@ -28,11 +59,11 @@ func TestContainerRemoveFailsCallsRemoveForcefully(t *testing.T) {
 	mic := &clients.ImageLog{}
 	dt := NewDockerTasks(md, mic, &TarGz{}, hclog.NewNullLogger())
 
-	md.On("ContainerRemove", mock.Anything, "test", types.ContainerRemoveOptions{Force: false, RemoveVolumes: true}).Return(fmt.Errorf("boom"))
+	md.On("ContainerRemove", mock.Anything, "test", types.ContainerRemoveOptions{Force: false, RemoveVolumes: true}).Return(nil)
 	md.On("ContainerRemove", mock.Anything, "test", types.ContainerRemoveOptions{Force: true, RemoveVolumes: true}).Return(nil)
 
-	dt.RemoveContainer("test")
+	dt.RemoveContainer("test", true)
 	md.AssertCalled(t, "ContainerRemove", mock.Anything, "test", types.ContainerRemoveOptions{Force: true, RemoveVolumes: true})
 
-	md.AssertNumberOfCalls(t, "ContainerRemove", 2)
+	md.AssertNumberOfCalls(t, "ContainerRemove", 1)
 }

--- a/pkg/clients/mocks/container_tasks.go
+++ b/pkg/clients/mocks/container_tasks.go
@@ -27,8 +27,8 @@ func (m *MockContainerTasks) ContainerInfo(id string) (interface{}, error) {
 	return args.Get(0), args.Error(1)
 }
 
-func (m *MockContainerTasks) RemoveContainer(id string) error {
-	args := m.Called(id)
+func (m *MockContainerTasks) RemoveContainer(id string, force bool) error {
+	args := m.Called(id, force)
 
 	return args.Error(0)
 }

--- a/pkg/providers/cluster_k3s.go
+++ b/pkg/providers/cluster_k3s.go
@@ -508,7 +508,7 @@ func (c *K8sCluster) destroyK3s() error {
 			}
 		}
 
-		err := c.client.RemoveContainer(i)
+		err := c.client.RemoveContainer(i, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/providers/cluster_nomad.go
+++ b/pkg/providers/cluster_nomad.go
@@ -444,7 +444,7 @@ func (c *NomadCluster) destroyNode(id string) error {
 			}
 		}
 
-		err := c.client.RemoveContainer(i)
+		err := c.client.RemoveContainer(i, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/providers/cluster_nomad_test.go
+++ b/pkg/providers/cluster_nomad_test.go
@@ -33,7 +33,7 @@ func setupNomadClusterMocks(t *testing.T) (*config.NomadCluster, *mocks.MockCont
 	md.On("CopyFromContainer", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	md.On("CopyLocalDockerImagesToVolume", mock.Anything, mock.Anything, mock.Anything).Return([]string{"file.tar.gz"}, nil)
 	md.On("ExecuteCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	md.On("RemoveContainer", mock.Anything).Return(nil)
+	md.On("RemoveContainer", mock.Anything, mock.Anything).Return(nil)
 	md.On("RemoveVolume", mock.Anything).Return(nil)
 	md.On("DetachNetwork", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
@@ -449,7 +449,7 @@ func TestClusterNomadDestroyRemovesConfig(t *testing.T) {
 
 	err := p.Destroy()
 	assert.NoError(t, err)
-	md.AssertCalled(t, "RemoveContainer", mock.Anything)
+	md.AssertCalled(t, "RemoveContainer", mock.Anything, mock.Anything)
 
 	assert.NoDirExists(t, dir)
 }

--- a/pkg/providers/container.go
+++ b/pkg/providers/container.go
@@ -111,16 +111,8 @@ func (c *Container) internalDestroy() error {
 
 	if len(ids) > 0 {
 		for _, id := range ids {
-			if c.config.Type == config.TypeContainer {
-				for _, n := range c.config.Networks {
-					err := c.client.DetachNetwork(n.Name, id)
-					if err != nil {
-						c.log.Warn("Unable to detach network", "ref", c.config.Name, "network", n.Name)
-					}
-				}
-			}
+			err := c.client.RemoveContainer(id, false)
 
-			err := c.client.RemoveContainer(id)
 			if err != nil {
 				return err
 			}

--- a/pkg/providers/container_test.go
+++ b/pkg/providers/container_test.go
@@ -146,7 +146,7 @@ func TestContainerDestroysCorrectlyWhenContainerExists(t *testing.T) {
 	c := NewContainer(cc, md, hc, hclog.NewNullLogger())
 
 	md.On("FindContainerIDs", cc.Name, cc.Type).Return([]string{"abc"}, nil)
-	md.On("RemoveContainer", "abc").Return(nil)
+	md.On("RemoveContainer", "abc", false).Return(nil)
 	md.On("DetachNetwork", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	err := c.Destroy()

--- a/pkg/providers/docs.go
+++ b/pkg/providers/docs.go
@@ -139,7 +139,7 @@ func (i *Docs) Destroy() error {
 	}
 
 	for _, id := range ids {
-		err := i.client.RemoveContainer(id)
+		err := i.client.RemoveContainer(id, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/providers/docs_test.go
+++ b/pkg/providers/docs_test.go
@@ -25,7 +25,7 @@ func setupDocs(t *testing.T) (*Docs, *mocks.MockContainerTasks) {
 	md.On("PullImage", mock.Anything, false).Return(nil)
 	md.On("CreateContainer", mock.Anything).Return("", nil)
 	md.On("FindContainerIDs", mock.Anything, mock.Anything).Return(nil, nil)
-	md.On("RemoveContainer", mock.Anything).Return(nil)
+	md.On("RemoveContainer", mock.Anything, true).Return(nil)
 
 	d := NewDocs(cc, md, hclog.NewNullLogger())
 

--- a/pkg/providers/exec_remote.go
+++ b/pkg/providers/exec_remote.go
@@ -102,7 +102,7 @@ func (c *ExecRemote) Create() error {
 
 	// destroy the container if we created one
 	if c.config.Target == "" {
-		c.client.RemoveContainer(targetID)
+		c.client.RemoveContainer(targetID, true)
 	}
 
 	return err

--- a/pkg/providers/exec_remote.go
+++ b/pkg/providers/exec_remote.go
@@ -2,7 +2,6 @@ package providers
 
 import (
 	"fmt"
-	"time"
 
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/shipyard-run/shipyard/pkg/clients"
@@ -110,7 +109,7 @@ func (c *ExecRemote) Create() error {
 
 func (c *ExecRemote) createRemoteExecContainer() (string, error) {
 	// generate the ID for the new container based on the clock time and a string
-	cc := config.NewContainer(fmt.Sprintf("%d.remote_exec", time.Now().Nanosecond()))
+	cc := config.NewContainer(fmt.Sprintf("%s.remote_exec", c.config.Name))
 	c.config.ResourceInfo.AddChild(cc)
 
 	cc.Networks = c.config.Networks

--- a/pkg/providers/exec_remote_test.go
+++ b/pkg/providers/exec_remote_test.go
@@ -17,7 +17,7 @@ func testRemoteExecSetupMocks() (*config.ExecRemote, *config.Network, *mocks.Moc
 	md.On("PullImage", mock.Anything, mock.Anything).Return(nil)
 	md.On("FindContainerIDs", mock.Anything).Return([]string{"1234"}, nil)
 	md.On("ExecuteCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	md.On("RemoveContainer", mock.Anything).Return(nil)
+	md.On("RemoveContainer", mock.Anything, true).Return(nil)
 	md.On("FindContainerIDs", mock.Anything, mock.Anything).Return([]string{"1234"}, nil)
 
 	trex := &config.ExecRemote{
@@ -167,7 +167,7 @@ func TestRemoteExecRemovesContainer(t *testing.T) {
 
 	err := p.Create()
 	assert.NoError(t, err)
-	md.AssertCalled(t, "RemoveContainer", "1234")
+	md.AssertCalled(t, "RemoveContainer", "1234", true)
 }
 
 /*

--- a/pkg/providers/image_cache.go
+++ b/pkg/providers/image_cache.go
@@ -131,8 +131,7 @@ func (c *ImageCache) Destroy() error {
 	// remove all networks that the container is attached to
 	if len(ids) > 0 {
 		for _, id := range ids {
-			c.detachFromNetworks(id)
-			c.client.RemoveContainer(id)
+			c.client.RemoveContainer(id, true)
 		}
 	}
 

--- a/pkg/providers/legacy_ingress.go
+++ b/pkg/providers/legacy_ingress.go
@@ -228,7 +228,9 @@ func (i *LegacyIngress) Destroy() error {
 			}
 		}
 
-		err := i.client.RemoveContainer(id)
+		// force remove as the container might get stuck due to the socat process
+		// this is safe for this container
+		err := i.client.RemoveContainer(id, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/providers/legacy_ingress_test.go
+++ b/pkg/providers/legacy_ingress_test.go
@@ -16,7 +16,7 @@ func testIngressCreateMocks() (*mocks.MockContainerTasks, *config.Config) {
 	md := &mocks.MockContainerTasks{}
 	md.On("PullImage", mock.Anything, mock.Anything).Return(nil)
 	md.On("CreateContainer", mock.Anything).Return("ingress", nil)
-	md.On("RemoveContainer", mock.Anything).Return(nil)
+	md.On("RemoveContainer", mock.Anything, true).Return(nil)
 	md.On("FindContainerIDs", mock.Anything, mock.Anything).Return([]string{}, nil)
 	md.On("DetachNetwork", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	md.On("CopyFileToContainer", mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -248,7 +248,7 @@ func TestIngressK8sTargetDestroysContainer(t *testing.T) {
 
 	err := p.Destroy()
 	assert.NoError(t, err)
-	md.AssertCalled(t, "RemoveContainer", "ingress")
+	md.AssertCalled(t, "RemoveContainer", "ingress", true)
 	md.AssertCalled(t, "DetachNetwork", mock.Anything, mock.Anything, mock.Anything)
 }
 


### PR DESCRIPTION
Previously when attempting to stop a container the code called RemoveContainer and when this failed would call RemoveContainer with force. The initial RemoveContainer would always fail as only a stopped container could be removed.

This PR introduces the correct behavior by first stopping and then attempting to remove the container.