### PR TITLE
log target completion

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"os"
+	
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate completion script",
+	Long: `To load completions:
+
+Bash:
+
+  $ source <(yourprogram completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ shipyard completion bash > /etc/bash_completion.d/shipyard
+  # macOS:
+  $ shipyard completion bash > /usr/local/etc/bash_completion.d/shipyard
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ ./shipyard completion zsh > "${fpath[1]}/_shipyard"
+
+  # You will need to start a new shell for this setup to take effect.
+  # I also had to disable oh-my-zsh calls in ~/.zshrc
+
+fish:
+
+  $ shipyard completion fish | source
+
+  # To load completions for each session, execute once:
+  $ shipyard completion fish > ~/.config/fish/completions/shipyard.fish
+
+PowerShell:
+
+  PS> shipyard completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> shipyard completion powershell > shipyard.ps1
+  # and source this file from your PowerShell profile.
+`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.ExactValidArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		switch args[0] {
+		case "bash":
+			cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+		}
+	},
+}

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -80,8 +80,8 @@ func getResources(cmd *cobra.Command, args []string, complete string) ([]string,
 				containers = append(containers, fmt.Sprintf("%d.client.%s", n+1, r.Info().Name))
 			}
 		default:
-			// no need to log these, right?
-			// containers = append(containers, r.Info().Name)
+			// These containers throw error
+			containers = append(containers, r.Info().Name)
 		}
 		allContainers = append(allContainers, containers...)
 	}

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -9,15 +9,16 @@ import (
 	"os"
 	"os/signal"
 	"sync"
-
+	
 	"github.com/docker/docker/api/types"
 	"github.com/fatih/color"
 	"github.com/hashicorp/go-hclog"
+	"github.com/spf13/cobra"
+	
 	"github.com/shipyard-run/shipyard/pkg/clients"
 	"github.com/shipyard-run/shipyard/pkg/config"
 	"github.com/shipyard-run/shipyard/pkg/shipyard"
 	"github.com/shipyard-run/shipyard/pkg/utils"
-	"github.com/spf13/cobra"
 )
 
 func newLogCmd(engine shipyard.Engine, dc clients.Docker, stdout, stderr io.Writer) *cobra.Command {
@@ -34,6 +35,7 @@ func newLogCmd(engine shipyard.Engine, dc clients.Docker, stdout, stderr io.Writ
 	shipyard log container.nginx
 	`,
 		Args: cobra.ArbitraryArgs,
+		ValidArgsFunction: getResources,
 		RunE: newLogCmdFunc(dc, stdout, stderr),
 	}
 
@@ -50,95 +52,82 @@ var termColors = []color.Attribute{
 	color.FgWhite,
 }
 
+func getResources(cmd *cobra.Command, args []string, complete string) ([]string, cobra.ShellCompDirective) {
+	loggable, err := getLoggable(args)
+	if err != nil {
+		return []string{err.Error()}, cobra.ShellCompDirectiveNoFileComp
+	}
+	
+	// all containers from all loggable resources
+	var allContainers []string
+	
+	for _, r := range loggable {
+		if r.Info().Disabled {
+			continue
+		}
+		var containers []string
+		// override the name for certain resources
+		switch r.Info().Type {
+		case config.TypeContainer:
+			containers = append(containers, "container."+r.Info().Name)
+		case config.TypeK8sCluster:
+			containers = append(containers, "server."+r.Info().Name)
+		case config.TypeNomadCluster:
+			containers = append(containers, "server."+r.Info().Name)
+			// add the client nodes
+			nomad := r.(*config.NomadCluster)
+			for n := 0; n < nomad.ClientNodes; n++ {
+				containers = append(containers, fmt.Sprintf("%d.client.%s", n+1, r.Info().Name))
+			}
+		default:
+			// no need to log these, right?
+			// containers = append(containers, r.Info().Name)
+		}
+		allContainers = append(allContainers, containers...)
+	}
+	return allContainers, cobra.ShellCompDirectiveNoFileComp
+	
+}
+
 func newLogCmdFunc(dc clients.Docker, stdout, stderr io.Writer) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		log := hclog.Default()
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs, os.Interrupt)
 		waitGroup := sync.WaitGroup{}
-
-		// get the list of resources that can be logged
-		c := config.New()
-		err := c.FromJSON(utils.StatePath())
+		
+		loggable, err := getLoggable(args)
 		if err != nil {
-			return fmt.Errorf("unable to load state file, check you have running resources: %s", err)
+			return err
 		}
-
-		// if an argument is provided, only tail logs for that resource
-		// first validate that the resource exists
-		resources := c.Resources
-		if len(args) > 0 {
-			r, err := c.FindResource(args[0])
-			if err != nil {
-				return fmt.Errorf("unable to find resource: %s", err)
-			}
-
-			resources = []config.Resource{r}
-		}
-
-		loggable := []config.Resource{}
-		for _, r := range resources {
-			switch r.Info().Type {
-			case config.TypeContainer:
-				if !r.Info().Disabled {
-					loggable = append(loggable, r)
-				}
-			case config.TypeK8sCluster:
-				if !r.Info().Disabled {
-					loggable = append(loggable, r)
-				}
-			case config.TypeNomadCluster:
-				if !r.Info().Disabled {
-					loggable = append(loggable, r)
-				}
-			case config.TypeSidecar:
-				if !r.Info().Disabled {
-					loggable = append(loggable, r)
-				}
-			case config.TypeK8sIngress:
-				if !r.Info().Disabled {
-					loggable = append(loggable, r)
-				}
-			case config.TypeNomadIngress:
-				if !r.Info().Disabled {
-					loggable = append(loggable, r)
-				}
-			case config.TypeContainerIngress:
-				if !r.Info().Disabled {
-					loggable = append(loggable, r)
-				}
-			case config.TypeImageCache:
-				loggable = append(loggable, r)
-			}
-		}
-
+		
 		ctx := context.Background()
-
+		
 		for _, r := range loggable {
 			if r.Info().Disabled {
 				continue
 			}
-
-			// resources can containe more than one container
+			
+			// resources can contain more than one container
 			containers := []string{}
-
+			
 			// override the name for certain resources
 			switch r.Info().Type {
 			case config.TypeK8sCluster:
 				containers = append(containers, "server."+r.Info().Name)
 			case config.TypeNomadCluster:
 				containers = append(containers, "server."+r.Info().Name)
-
+				
 				// add the client nodes
 				nomad := r.(*config.NomadCluster)
 				for n := 0; n < nomad.ClientNodes; n++ {
 					containers = append(containers, fmt.Sprintf("%d.client.%s", n+1, r.Info().Name))
 				}
-
+			
 			default:
 				containers = append(containers, r.Info().Name)
 			}
-
+			
 			for _, container := range containers {
 				rc, err := dc.ContainerLogs(
 					ctx,
@@ -150,7 +139,7 @@ func newLogCmdFunc(dc clients.Docker, stdout, stderr io.Writer) func(cmd *cobra.
 						Tail:       "40",
 					},
 				)
-
+				
 				if err == nil {
 					waitGroup.Add(1)
 					go func(rc io.ReadCloser, name string, c color.Attribute, log hclog.Logger) {
@@ -162,19 +151,78 @@ func newLogCmdFunc(dc clients.Docker, stdout, stderr io.Writer) func(cmd *cobra.
 				}
 			}
 		}
-
-		// send an interupt when the waitgroup is done
+		
+		// send an interrupt when the waitGroup is done
 		go func() {
 			waitGroup.Wait()
 			log.Info("No more logs to tail")
 			sigs <- os.Interrupt
 		}()
-
+		
 		// block until a signal is received
 		<-sigs
-
+		
 		return nil
 	}
+}
+// if this methods returns and error, it will get returned as shell-completion data
+// otherwise fmt.println() gets lost
+func getLoggable(args []string) ([]config.Resource, error) {
+	// get the list of resources that can be logged
+	c := config.New()
+	err := c.FromJSON(utils.StatePath())
+	if err != nil {
+		return nil, fmt.Errorf("unable to load state file, check you have running resources: %s", err)
+	}
+	
+	// if an argument is provided, only tail logs for that resource
+	// first validate that the resource exists
+	resources := c.Resources
+	if len(args) > 0 {
+		r, err := c.FindResource(args[0])
+		if err != nil {
+			return nil, fmt.Errorf("unable to find resource: %s", err)
+		}
+		
+		resources = []config.Resource{r}
+	}
+	
+	loggable := []config.Resource{}
+	for _, r := range resources {
+		switch r.Info().Type {
+		case config.TypeContainer:
+			if !r.Info().Disabled {
+				loggable = append(loggable, r)
+			}
+		case config.TypeK8sCluster:
+			if !r.Info().Disabled {
+				loggable = append(loggable, r)
+			}
+		case config.TypeNomadCluster:
+			if !r.Info().Disabled {
+				loggable = append(loggable, r)
+			}
+		case config.TypeSidecar:
+			if !r.Info().Disabled {
+				loggable = append(loggable, r)
+			}
+		case config.TypeK8sIngress:
+			if !r.Info().Disabled {
+				loggable = append(loggable, r)
+			}
+		case config.TypeNomadIngress:
+			if !r.Info().Disabled {
+				loggable = append(loggable, r)
+			}
+		case config.TypeContainerIngress:
+			if !r.Info().Disabled {
+				loggable = append(loggable, r)
+			}
+		case config.TypeImageCache:
+			loggable = append(loggable, r)
+		}
+	}
+	return loggable, nil
 }
 
 func getRandomColor() color.Attribute {

--- a/cmd/log_test.go
+++ b/cmd/log_test.go
@@ -6,12 +6,13 @@ import (
 	"io"
 	"sync"
 	"testing"
-
+	
 	"github.com/docker/docker/api/types"
-	"github.com/shipyard-run/shipyard/pkg/clients/mocks"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	
+	"github.com/shipyard-run/shipyard/pkg/clients/mocks"
 )
 
 const (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,12 +3,13 @@ package cmd
 import (
 	"fmt"
 	"os"
-
+	
 	"github.com/hashicorp/go-hclog"
+	gvm "github.com/shipyard-run/version-manager"
+	
 	"github.com/shipyard-run/shipyard/pkg/shipyard"
 	"github.com/shipyard-run/shipyard/pkg/utils"
-	gvm "github.com/shipyard-run/version-manager"
-
+	
 	"github.com/spf13/cobra"
 )
 
@@ -58,7 +59,8 @@ func init() {
 	rootCmd.AddCommand(newVersionCmd(vm))
 	rootCmd.AddCommand(uninstallCmd)
 	rootCmd.AddCommand(newPushCmd(engineClients.ContainerTasks, engineClients.Kubernetes, engineClients.HTTP, engineClients.Nomad, logger))
-	rootCmd.AddCommand(newLogCmd(engine, engineClients.Docker, os.Stdout, os.Stderr))
+	rootCmd.AddCommand(newLogCmd(engine, engineClients.Docker, os.Stdout, os.Stderr), completionCmd)
+	
 	// add the server commands
 	rootCmd.AddCommand(connectorCmd)
 	connectorCmd.AddCommand(newConnectorRunCommand())


### PR DESCRIPTION
Adds shell completions for `shipyard log [tab]`
```txt
% ./shipyard log [tab]
consul-container-http  container.consul       docker-cache           envoy
```
At present, shell completion only works where logs work, i.e only for containers. [#134](https://github.com/shipyard-run/shipyard/pull/134#issue-706585893)

Expanding this to Kubernetes & Nomad would be pretty straightforward. 

Can also add shell completions to `shipyard exec`

Single time setup to enable completions - 

1. Run `./shipyard completion --help` to list steps for sourcing shell completions.
2. Run commands corresponding to your shell
3. `shipyard log [tab]` would now work

For zsh, I also had to disable oh-my-zsh calls in ~/.zshrc

Cobra shell completion info [here](https://github.com/spf13/cobra/blob/master/shell_completions.md#creating-your-own-completion-command)