### PR TITLE
Do not import docker images when name empty

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go version
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16.10
+          go-version: 1.17
 
       - name: Install dependencies for Podman
         run: |
@@ -40,7 +40,7 @@ jobs:
         if: always()
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          tile: ${{ github.job_id }}
+          title: ${{ github.job_id }}
 
   functional_test:
     name: Functional Test
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Go version
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16.10
+          go-version: 1.17
       
       - name: Install dependencies for Podman
         run: |
@@ -96,7 +96,7 @@ jobs:
       - name: Setup Go version
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16.10
+          go-version: 1.17
       
       - name: Install dependencies for Podman
         run: |
@@ -153,7 +153,7 @@ jobs:
       - name: Setup Go version
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16.10
+          go-version: 1.17
       
       - name: Install dependencies for Podman
         run: |
@@ -302,7 +302,7 @@ jobs:
       - name: Setup Go version
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16.10
+          go-version: 1.17
       
       - name: Install dependencies for Podman
         run: |

--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -162,7 +162,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:
-          version: v0.172.1
+          version: v1.4.1
           args: release --rm-dist --snapshot
           key: ${{ secrets.GPG_PRIVATE_KEY }}
         env:
@@ -317,7 +317,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:
-          version: v0.164.0
+          version: v1.4.1
           args: release --rm-dist
           key: ${{ secrets.GPG_PRIVATE_KEY }}
         env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,6 +26,7 @@ builds:
     - amd64
     - arm
     - arm64
+
   goarm:
     - 7
     - 6

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,7 @@
 # Change Log
 
+## version v0.3.40
+* Do not attempt to import Docker images to Nomad and Kubernetes clusters when the Name is ""
 ## version v0.3.37
 * Adds capability for complex variable types and variable interpolation in templates. Previously,
 all `vars` in `template` resources were interpreted as strings. This change now allows richer types

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -46,8 +46,8 @@ func newDestroyCmd(cc clients.Connector) *cobra.Command {
 				os.RemoveAll(utils.CertsDir(""))
 			}
 
-			// shutdown ingress
-			if cc.IsRunning() {
+			// shutdown ingress when we destroy all resources
+			if cc.IsRunning() && dst == "" {
 				err = cc.Stop()
 				if err != nil {
 					hclog.Default().Error("Unable to stop ingress", "error", err)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shipyard-run/shipyard
 
-go 1.16
+go 1.17
 
 require (
 	github.com/BurntSushi/toml v0.4.1 // indirect
@@ -8,7 +8,6 @@ require (
 	github.com/MichaelMure/go-term-markdown v0.1.3
 	github.com/Microsoft/go-winio v0.5.0 // indirect
 	github.com/Microsoft/hcsshim v0.8.22 // indirect
-	github.com/barkimedes/go-deepcopy v0.0.0-20200817023428-a044a1957ca4
 	github.com/creack/pty v1.1.11
 	github.com/cucumber/godog v0.10.0
 	github.com/cucumber/messages-go/v10 v10.0.3
@@ -64,7 +63,157 @@ require (
 	k8s.io/client-go v0.22.4
 )
 
-replace github.com/creack/pty => github.com/shipyard-run/pty v1.1.12-0.20210531091229-b834701fbcc6
+require (
+	cloud.google.com/go v0.81.0 // indirect
+	cloud.google.com/go/storage v1.10.0 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/semver/v3 v3.1.1 // indirect
+	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
+	github.com/Masterminds/squirrel v1.5.2 // indirect
+	github.com/MichaelMure/go-term-text v0.2.7 // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/agext/levenshtein v1.2.2 // indirect
+	github.com/alecthomas/chroma v0.7.1 // indirect
+	github.com/andybalholm/brotli v1.0.0 // indirect
+	github.com/apparentlymart/go-textseg v1.0.0 // indirect
+	github.com/apparentlymart/go-textseg/v12 v12.0.0 // indirect
+	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 // indirect
+	github.com/aws/aws-sdk-go v1.34.9 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/containerd/containerd v1.5.7 // indirect
+	github.com/cucumber/gherkin-go/v11 v11.0.0 // indirect
+	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/disintegration/imaging v1.6.2 // indirect
+	github.com/dlclark/regexp2 v1.1.6 // indirect
+	github.com/docker/cli v20.10.7+incompatible // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/docker/go-metrics v0.0.1 // indirect
+	github.com/docker/go-units v0.4.0 // indirect
+	github.com/eliukblau/pixterm/pkg/ansimage v0.0.0-20191210081756-9fb6cf8c2f75 // indirect
+	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
+	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
+	github.com/fasthttp/websocket v1.4.3 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/jsonreference v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.14 // indirect
+	github.com/go-playground/locales v0.13.0 // indirect
+	github.com/go-playground/universal-translator v0.17.0 // indirect
+	github.com/go-playground/validator/v10 v10.3.0 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/gofrs/uuid v3.2.0+incompatible // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/gomarkdown/markdown v0.0.0-20191123064959-2c17d62f5098 // indirect
+	github.com/google/btree v1.0.1 // indirect
+	github.com/google/go-github v17.0.0+incompatible // indirect
+	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
+	github.com/guillermo/go.procstat v0.0.0-20131123175440-34c2813d2e7f // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-immutable-radix v1.2.0 // indirect
+	github.com/hashicorp/go-memdb v1.2.1 // indirect
+	github.com/hashicorp/go-safetemp v1.0.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/hashicorp/hcl/v2 v2.3.0 // indirect
+	github.com/huandu/xstrings v1.3.2 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.3.0 // indirect
+	github.com/jmoiron/sqlx v1.3.1 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/kyokomi/emoji v2.1.0+incompatible // indirect
+	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
+	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
+	github.com/leodido/go-urn v1.2.0 // indirect
+	github.com/lib/pq v1.10.0 // indirect
+	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
+	github.com/lucasb-eyer/go-colorful v1.0.3 // indirect
+	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/mitchellh/copystructure v1.1.1 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-ps v1.0.0 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.1 // indirect
+	github.com/moby/locker v1.0.1 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/morikuni/aec v1.0.0 // indirect
+	github.com/onsi/ginkgo v1.16.4 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_golang v1.11.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.26.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/rubenv/sql-migrate v0.0.0-20210614095031-55d5740dbbcc // indirect
+	github.com/russross/blackfriday v1.5.2 // indirect
+	github.com/savsgio/gotils v0.0.0-20200608150037-a5f6f5aef16c // indirect
+	github.com/shopspring/decimal v1.2.0 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasthttp v1.18.0 // indirect
+	github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	go.opencensus.io v0.23.0 // indirect
+	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
+	golang.org/x/image v0.0.0-20191206065243-da761ea9ff43 // indirect
+	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
+	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	golang.org/x/tools v0.1.2 // indirect
+	google.golang.org/api v0.44.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/gorp.v1 v1.7.2 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/apiextensions-apiserver v0.22.4 // indirect
+	k8s.io/apiserver v0.22.4 // indirect
+	k8s.io/cli-runtime v0.22.4 // indirect
+	k8s.io/component-base v0.22.4 // indirect
+	k8s.io/klog/v2 v2.9.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20211109043538-20434351676c // indirect
+	k8s.io/kubectl v0.22.4 // indirect
+	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a // indirect
+	oras.land/oras-go v0.4.0 // indirect
+	sigs.k8s.io/kustomize/api v0.8.11 // indirect
+	sigs.k8s.io/kustomize/kyaml v0.11.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
+)
+
+replace github.com/creack/pty => github.com/donorp/pty v1.1.12-0.20211004111936-294eccab62ed
 
 //replace golang.org/x/sys/windows => golang.org/x/sys/windows v0.0.0-20191005200804-aed5e5c7ecf12
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/MichaelMure/go-term-markdown v0.1.3
 	github.com/Microsoft/go-winio v0.5.0 // indirect
 	github.com/Microsoft/hcsshim v0.8.22 // indirect
+	github.com/barkimedes/go-deepcopy v0.0.0-20200817023428-a044a1957ca4
 	github.com/creack/pty v1.1.11
 	github.com/cucumber/godog v0.10.0
 	github.com/cucumber/messages-go/v10 v10.0.3

--- a/go.sum
+++ b/go.sum
@@ -190,6 +190,8 @@ github.com/aws/aws-sdk-go v1.30.12/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZve
 github.com/aws/aws-sdk-go v1.34.9 h1:cUGBW9CVdi0mS7K1hDzxIqTpfeWhpoQiguq81M1tjK0=
 github.com/aws/aws-sdk-go v1.34.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
+github.com/barkimedes/go-deepcopy v0.0.0-20200817023428-a044a1957ca4 h1:iBbhlt5YmtL9QXsMVf/XPXgYBQLifn38Cdjc0J/+uYg=
+github.com/barkimedes/go-deepcopy v0.0.0-20200817023428-a044a1957ca4/go.mod h1:hiVxq5OP2bUGBRNS3Z/bt/reCLFNbdcST6gISi1fiOM=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,6 @@ github.com/aws/aws-sdk-go v1.30.12/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZve
 github.com/aws/aws-sdk-go v1.34.9 h1:cUGBW9CVdi0mS7K1hDzxIqTpfeWhpoQiguq81M1tjK0=
 github.com/aws/aws-sdk-go v1.34.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
-github.com/barkimedes/go-deepcopy v0.0.0-20200817023428-a044a1957ca4 h1:iBbhlt5YmtL9QXsMVf/XPXgYBQLifn38Cdjc0J/+uYg=
-github.com/barkimedes/go-deepcopy v0.0.0-20200817023428-a044a1957ca4/go.mod h1:hiVxq5OP2bUGBRNS3Z/bt/reCLFNbdcST6gISi1fiOM=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -418,6 +416,8 @@ github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 h1:UhxFibDNY/bfvqU
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/donorp/pty v1.1.12-0.20211004111936-294eccab62ed h1:vO7um1IKGVZSuA/8vTY6uei/5R3m2YpnFxwQcZRbtw0=
+github.com/donorp/pty v1.1.12-0.20211004111936-294eccab62ed/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dylanmei/iso8601 v0.1.0/go.mod h1:w9KhXSgIyROl1DefbMYIE7UVSIvELTbMrCfx+QkYnoQ=
@@ -1120,8 +1120,6 @@ github.com/shipyard-run/connector v0.1.0 h1:qmSY3StxYCHteIHtCFnjnSVQFOEPAvaKu8kl
 github.com/shipyard-run/connector v0.1.0/go.mod h1:hEKWnx/tRxSVoGPUeoSUSPwpos+8ceTQF5/gdIOST/I=
 github.com/shipyard-run/gohup v0.2.2 h1:yIJhQ7BItGd2cZmWeuxCneTNriIxLGaPtMt1FsW191A=
 github.com/shipyard-run/gohup v0.2.2/go.mod h1:jgPnkGXOn4ca6tCWUHw2FUhhvxiMskROiRIoYMYEYHM=
-github.com/shipyard-run/pty v1.1.12-0.20210531091229-b834701fbcc6 h1:1Q4lxUwRGbZZCQQQftmhRhZ7GlWwQv/ukvj6bbqqhlI=
-github.com/shipyard-run/pty v1.1.12-0.20210531091229-b834701fbcc6/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/shipyard-run/version-manager v0.0.5 h1:gswTn7y/f2yoUOGl9tu18Bbp84EQa7gtqMNBbPu78BA=
 github.com/shipyard-run/version-manager v0.0.5/go.mod h1:odqsb09c70cTpSnm1rhQpBV1j7dF3N1FGzdiz8W0n+c=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=

--- a/pkg/providers/cluster_k3s.go
+++ b/pkg/providers/cluster_k3s.go
@@ -464,6 +464,11 @@ func (c *K8sCluster) ImportLocalDockerImages(name string, id string, images []co
 	imgs := []string{}
 
 	for _, i := range images {
+		// do nothing when the image name is empty
+		if i.Name == "" {
+			continue
+		}
+
 		err := c.client.PullImage(i, false)
 		if err != nil {
 			return err

--- a/pkg/providers/cluster_k3s_test.go
+++ b/pkg/providers/cluster_k3s_test.go
@@ -417,6 +417,20 @@ func TestClusterK3sStreamsLogsWhenRunning(t *testing.T) {
 	assert.NoError(t, logReader.Close())
 }
 
+func TestClusterK3sImportDockerImagesDoesNothingWhenEmpty(t *testing.T) {
+	cc, md, mk, mc := setupClusterMocks(t)
+
+	cc.Images[0].Name = ""
+
+	p := NewK8sCluster(cc, md, mk, nil, mc, hclog.NewNullLogger())
+
+	err := p.Create()
+	assert.NoError(t, err)
+	md.AssertNumberOfCalls(t, "PullImage", 2)
+	md.AssertNotCalled(t, "PullImage", clusterConfig.Images[0], false)
+	md.AssertCalled(t, "PullImage", clusterConfig.Images[1], false)
+}
+
 func TestClusterK3sImportDockerImagesPullsImages(t *testing.T) {
 	cc, md, mk, mc := setupClusterMocks(t)
 
@@ -424,6 +438,7 @@ func TestClusterK3sImportDockerImagesPullsImages(t *testing.T) {
 
 	err := p.Create()
 	assert.NoError(t, err)
+	md.AssertNumberOfCalls(t, "PullImage", 3)
 	md.AssertCalled(t, "PullImage", clusterConfig.Images[0], false)
 	md.AssertCalled(t, "PullImage", clusterConfig.Images[1], false)
 }

--- a/pkg/providers/cluster_k3s_test.go
+++ b/pkg/providers/cluster_k3s_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/mohae/deepcopy"
 	"github.com/shipyard-run/shipyard/pkg/clients"
 	"github.com/shipyard-run/shipyard/pkg/clients/mocks"
 	"github.com/shipyard-run/shipyard/pkg/config"
@@ -81,18 +82,18 @@ func setupClusterMocks(t *testing.T) (
 	).Return(&clients.CertBundle{}, nil)
 
 	// copy the config
-	cc := *clusterConfig
-	cn := *clusterNetwork
+	cc := deepcopy.Copy(clusterConfig).(*config.K8sCluster)
+	cn := deepcopy.Copy(clusterNetwork).(*config.Network)
 
 	c := config.New()
-	c.AddResource(&cc)
-	c.AddResource(&cn)
+	c.AddResource(cc)
+	c.AddResource(cn)
 
 	t.Cleanup(func() {
 		os.Setenv(utils.HomeEnvName(), currentHome)
 	})
 
-	return &cc, md, mk, mc
+	return cc, md, mk, mc
 }
 
 func TestClusterK3ErrorsWhenUnableToLookupIDs(t *testing.T) {
@@ -427,8 +428,8 @@ func TestClusterK3sImportDockerImagesDoesNothingWhenEmpty(t *testing.T) {
 	err := p.Create()
 	assert.NoError(t, err)
 	md.AssertNumberOfCalls(t, "PullImage", 2)
-	md.AssertNotCalled(t, "PullImage", clusterConfig.Images[0], false)
-	md.AssertCalled(t, "PullImage", clusterConfig.Images[1], false)
+	md.AssertNotCalled(t, "PullImage", cc.Images[0], false)
+	md.AssertCalled(t, "PullImage", cc.Images[1], false)
 }
 
 func TestClusterK3sImportDockerImagesPullsImages(t *testing.T) {
@@ -439,8 +440,8 @@ func TestClusterK3sImportDockerImagesPullsImages(t *testing.T) {
 	err := p.Create()
 	assert.NoError(t, err)
 	md.AssertNumberOfCalls(t, "PullImage", 3)
-	md.AssertCalled(t, "PullImage", clusterConfig.Images[0], false)
-	md.AssertCalled(t, "PullImage", clusterConfig.Images[1], false)
+	md.AssertCalled(t, "PullImage", cc.Images[0], false)
+	md.AssertCalled(t, "PullImage", cc.Images[1], false)
 }
 
 func TestClusterK3sImportDockerCopiesImages(t *testing.T) {

--- a/pkg/providers/cluster_nomad.go
+++ b/pkg/providers/cluster_nomad.go
@@ -426,6 +426,11 @@ func (c *NomadCluster) ImportLocalDockerImages(name string, id string, images []
 	imgs := []string{}
 
 	for _, i := range images {
+		// ignore when the name is empty
+		if i.Name == "" {
+			continue
+		}
+
 		err := c.client.PullImage(i, false)
 		if err != nil {
 			return err

--- a/pkg/providers/cluster_nomad_test.go
+++ b/pkg/providers/cluster_nomad_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/mohae/deepcopy"
 	"github.com/shipyard-run/shipyard/pkg/clients/mocks"
 	"github.com/shipyard-run/shipyard/pkg/config"
 	"github.com/shipyard-run/shipyard/pkg/utils"
@@ -50,18 +51,18 @@ func setupNomadClusterMocks(t *testing.T) (*config.NomadCluster, *mocks.MockCont
 	ioutil.WriteFile(cafile, []byte("CA"), os.ModePerm)
 
 	// copy the config
-	cc := *clusterNomadConfig
+	cc := deepcopy.Copy(clusterNomadConfig).(*config.NomadCluster)
 	cn := *clusterNetwork
 
 	c := config.New()
-	c.AddResource(&cc)
+	c.AddResource(cc)
 	c.AddResource(&cn)
 
 	t.Cleanup(func() {
 		os.Setenv("HOME", currentHome)
 	})
 
-	return &cc, md, mh
+	return cc, md, mh
 }
 
 func TestClusterNomadErrorsWhenUnableToLookupIDs(t *testing.T) {
@@ -298,6 +299,7 @@ func TestClusterNomadImportDockerImagesDoesNothingWhenNameEmpty(t *testing.T) {
 
 func TestClusterNomadImportDockerImagesPullsImages(t *testing.T) {
 	cc, md, mh := setupNomadClusterMocks(t)
+	cc.Images[0].Name = ""
 
 	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
 

--- a/pkg/providers/cluster_nomad_test.go
+++ b/pkg/providers/cluster_nomad_test.go
@@ -288,14 +288,13 @@ func TestClusterNomadErrorsIfHealthFails(t *testing.T) {
 func TestClusterNomadImportDockerImagesDoesNothingWhenNameEmpty(t *testing.T) {
 	cc, md, mh := setupNomadClusterMocks(t)
 	cc.Images[0].Name = ""
-
 	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
 
 	err := p.Create()
 	assert.NoError(t, err)
 	md.AssertNumberOfCalls(t, "PullImage", 2)
-	md.AssertNotCalled(t, "PullImage", clusterConfig.Images[0], false)
-	md.AssertCalled(t, "PullImage", clusterConfig.Images[1], false)
+	md.AssertNotCalled(t, "PullImage", cc.Images[0], false)
+	md.AssertCalled(t, "PullImage", cc.Images[1], false)
 }
 
 func TestClusterNomadImportDockerImagesPullsImages(t *testing.T) {
@@ -306,8 +305,8 @@ func TestClusterNomadImportDockerImagesPullsImages(t *testing.T) {
 	err := p.Create()
 	assert.NoError(t, err)
 	md.AssertNumberOfCalls(t, "PullImage", 3)
-	md.AssertCalled(t, "PullImage", clusterConfig.Images[0], false)
-	md.AssertCalled(t, "PullImage", clusterConfig.Images[1], false)
+	md.AssertCalled(t, "PullImage", cc.Images[0], false)
+	md.AssertCalled(t, "PullImage", cc.Images[1], false)
 }
 
 func TestClusterNomadImportDockerCopiesImages(t *testing.T) {

--- a/pkg/providers/cluster_nomad_test.go
+++ b/pkg/providers/cluster_nomad_test.go
@@ -283,6 +283,19 @@ func TestClusterNomadErrorsIfHealthFails(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestClusterNomadImportDockerImagesDoesNothingWhenNameEmpty(t *testing.T) {
+	cc, md, mh := setupNomadClusterMocks(t)
+	cc.Images[0].Name = ""
+
+	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
+
+	err := p.Create()
+	assert.NoError(t, err)
+	md.AssertNumberOfCalls(t, "PullImage", 2)
+	md.AssertNotCalled(t, "PullImage", clusterConfig.Images[0], false)
+	md.AssertCalled(t, "PullImage", clusterConfig.Images[1], false)
+}
+
 func TestClusterNomadImportDockerImagesPullsImages(t *testing.T) {
 	cc, md, mh := setupNomadClusterMocks(t)
 
@@ -290,6 +303,7 @@ func TestClusterNomadImportDockerImagesPullsImages(t *testing.T) {
 
 	err := p.Create()
 	assert.NoError(t, err)
+	md.AssertNumberOfCalls(t, "PullImage", 3)
 	md.AssertCalled(t, "PullImage", clusterConfig.Images[0], false)
 	md.AssertCalled(t, "PullImage", clusterConfig.Images[1], false)
 }

--- a/pkg/providers/cluster_nomad_test.go
+++ b/pkg/providers/cluster_nomad_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
+
 	"github.com/mohae/deepcopy"
 	"github.com/shipyard-run/shipyard/pkg/clients/mocks"
 	"github.com/shipyard-run/shipyard/pkg/config"
@@ -299,7 +300,6 @@ func TestClusterNomadImportDockerImagesDoesNothingWhenNameEmpty(t *testing.T) {
 
 func TestClusterNomadImportDockerImagesPullsImages(t *testing.T) {
 	cc, md, mh := setupNomadClusterMocks(t)
-	cc.Images[0].Name = ""
 
 	p := NewNomadCluster(cc, md, mh, hclog.NewNullLogger())
 


### PR DESCRIPTION
When an empty image name is specified such as when a default variable is empty. Currently, Shipyard will attempt to pull this image and subsequently fail. This PR changes the behavior to ignore empty image names, this enables module developers to specify a variable that has no initial value.

```  
k8s_cluster "test" {
  image {
    name = var.image_import_name
  }
}
```