### PR TITLE
adds `NOMAD_ADDR` to outputs

### DIFF
--- a/examples/nomad/output.hcl
+++ b/examples/nomad/output.hcl
@@ -1,3 +1,7 @@
 output "NOMAD_HTTP_ADDR" {
   value = cluster_api("nomad_cluster.dev")
 }
+
+output "NOMAD_ADDR" {
+  value = cluster_api("nomad_cluster.dev")
+}


### PR DESCRIPTION
Hello maintainers 👋🏼 

This adds `NOMAD_ADDR` to outputs, to allow for easier consumption of this blueprint downstream