### PR TITLE
Add new Copy and Certificates resources

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,41 @@
 # Change Log
 
+## version v0.4.0
+* Add new resource to enable copying resources
+
+```hcl
+copy "testing" {
+	source = "/"
+	destination = "/path"
+
+	permissions = "0700"
+}
+```
+
+* Add new resource to enable generation of certificates
+
+```hcl
+certificate_ca "testing" {
+	output = "/"
+}
+
+certificate_leaf "testing" {
+	ip_addresses = ["a","b"]
+	dns_names = ["1","2"]
+
+	ca_cert = "./file"
+	ca_key = "./file"
+
+	output = "/"
+}
+```
+
+* Add new function to allow the creation of data directories with specific permissions
+
+```hcl
+data_with_permissions("name","0777")
+```
+
 ## version v0.3.50
 * Sanitize helm chart names replacing non acceptable characters
 

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -40,7 +40,7 @@ func newDestroyCmd(cc clients.Connector) *cobra.Command {
 
 			if dst == "" {
 				// clean up the data folder
-				os.RemoveAll(utils.GetDataFolder(""))
+				os.RemoveAll(utils.GetDataFolder("", os.ModePerm))
 
 				// remove the certs
 				os.RemoveAll(utils.CertsDir(""))

--- a/cmd/purge.go
+++ b/cmd/purge.go
@@ -99,7 +99,7 @@ func newPurgeCmdFunc(dt clients.Docker, il clients.ImageLog, l hclog.Logger) fun
 			bHasError = true
 		}
 
-		dcp := utils.GetDataFolder("")
+		dcp := utils.GetDataFolder("", os.ModePerm)
 		l.Info("Removing data folders", "path", dcp)
 		err = os.RemoveAll(dcp)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/opencontainers/image-spec v1.0.2
+	github.com/otiai10/copy v1.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/shipyard-run/connector v0.1.0
 	github.com/shipyard-run/gohup v0.2.2

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/otiai10/copy v1.7.0
 	github.com/pkg/errors v0.9.1
+	github.com/sethvargo/go-retry v0.2.3
 	github.com/shipyard-run/connector v0.1.0
 	github.com/shipyard-run/gohup v0.2.2
 	github.com/shipyard-run/version-manager v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -1253,6 +1253,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/sethvargo/go-retry v0.2.3 h1:oYlgvIvsju3jNbottWABtbnoLC+GDtLdBHxKWxQm/iU=
+github.com/sethvargo/go-retry v0.2.3/go.mod h1:1afjQuvh7s4gflMObvjLPaWgluLLyhA1wmVZ6KLpICw=
 github.com/shipyard-run/connector v0.1.0 h1:qmSY3StxYCHteIHtCFnjnSVQFOEPAvaKu8klccdqrWI=
 github.com/shipyard-run/connector v0.1.0/go.mod h1:hEKWnx/tRxSVoGPUeoSUSPwpos+8ceTQF5/gdIOST/I=
 github.com/shipyard-run/gohup v0.2.2 h1:yIJhQ7BItGd2cZmWeuxCneTNriIxLGaPtMt1FsW191A=

--- a/go.sum
+++ b/go.sum
@@ -1151,6 +1151,13 @@ github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/otiai10/copy v1.7.0 h1:hVoPiN+t+7d2nzzwMiDHPSOogsWAStewq3TwU05+clE=
+github.com/otiai10/copy v1.7.0/go.mod h1:rmRl6QPdJj6EiUqXQ/4Nn2lLXoNQjFCQbbNrxgc/t3U=
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
+github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/otiai10/mint v1.3.3 h1:7JgpsBaN0uMkyju4tbYHu0mnM55hNKVYLsXmwr15NQI=
+github.com/otiai10/mint v1.3.3/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/packer-community/winrmcp v0.0.0-20180102160824-81144009af58/go.mod h1:f6Izs6JvFTdnRbziASagjZ2vmf55NSIkC/weStxCHqk=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/pkg/config/cert.go
+++ b/pkg/config/cert.go
@@ -26,8 +26,8 @@ type CertificateLeaf struct {
 
 	Depends []string `hcl:"depends_on,optional" json:"depends,omitempty"`
 
-	CAKey  string `hcl:"ca_key" json:"ca_key"`   // Path to the primary key for the root CA
-	CACert string `hcl:"ca_cert" json:"ca_cert"` // Path to the root CA
+	CAKey  string `hcl:"ca_key" json:"ca_key" mapstructure:"ca_key"`    // Path to the primary key for the root CA
+	CACert string `hcl:"ca_cert" json:"ca_cert" mapstructure:"ca_cert"` // Path to the root CA
 
 	IPAddresses []string `hcl:"ip_addresses,optional" json:"ip_addresses,omitempty" mapstructure:"ip_addresses"` // ip addresses to add to the cert
 	DNSNames    []string `hcl:"dns_names,optional" json:"dns_names,omitempty" mapstructure:"dns_names"`          // DNS names to add to the cert

--- a/pkg/config/cert.go
+++ b/pkg/config/cert.go
@@ -1,0 +1,41 @@
+package config
+
+// TypeCertificateCA is the resource string for a self-signed CA
+const TypeCertificateCA ResourceType = "certificate_ca"
+
+// CertificateCA allows the generate of CA certificates
+type CertificateCA struct {
+	ResourceInfo `hcl:",remain" mapstructure:",squash"`
+
+	Depends []string `hcl:"depends_on,optional" json:"depends,omitempty"`
+
+	Output string `hcl:"output" json:"output"`
+}
+
+// NewCertificateCA creates a new CA certificate config resource
+func NewCertificateCA(name string) *CertificateCA {
+	return &CertificateCA{ResourceInfo: ResourceInfo{Name: name, Type: TypeCertificateCA, Status: PendingCreation}}
+}
+
+// TypeCertificateCA is the resource string for a self-signed CA
+const TypeCertificateLeaf ResourceType = "certificate_leaf"
+
+// CertificateCA allows the generate of CA certificates
+type CertificateLeaf struct {
+	ResourceInfo `hcl:",remain" mapstructure:",squash"`
+
+	Depends []string `hcl:"depends_on,optional" json:"depends,omitempty"`
+
+	CAKey  string `hcl:"ca_key" json:"ca_key"`   // Path to the primary key for the root CA
+	CACert string `hcl:"ca_cert" json:"ca_cert"` // Path to the root CA
+
+	IPAddresses []string `hcl:"ip_addresses,optional" json:"ip_addresses,omitempty" mapstructure:"ip_addresses"` // ip addresses to add to the cert
+	DNSNames    []string `hcl:"dns_names,optional" json:"dns_names,omitempty" mapstructure:"dns_names"`          // DNS names to add to the cert
+
+	Output string `hcl:"output" json:"output"` // output location for the certificate
+}
+
+// NewCertificateLeaf creates a new Leaf certificate resource
+func NewCertificateLeaf(name string) *CertificateLeaf {
+	return &CertificateLeaf{ResourceInfo: ResourceInfo{Name: name, Type: TypeCertificateLeaf, Status: PendingCreation}}
+}

--- a/pkg/config/cert_test.go
+++ b/pkg/config/cert_test.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCreatesCertificateCA(t *testing.T) {
+	c := NewCertificateCA("abc")
+
+	assert.Equal(t, "abc", c.Name)
+	assert.Equal(t, TypeCertificateCA, c.Type)
+}
+
+func TestCertificateCACreatesCorrectly(t *testing.T) {
+	c, _ := CreateConfigFromStrings(t, certificateCA)
+
+	cl, err := c.FindResource("certificate_ca.testing")
+	assert.NoError(t, err)
+
+	assert.Equal(t, "testing", cl.Info().Name)
+	assert.Equal(t, TypeCertificateCA, cl.Info().Type)
+	assert.Equal(t, PendingCreation, cl.Info().Status)
+}
+
+func TestCertificateCADisabled(t *testing.T) {
+	c, _ := CreateConfigFromStrings(t, certificateCADisabled)
+
+	cl, err := c.FindResource("certificate_ca.testing")
+	assert.NoError(t, err)
+
+	assert.Equal(t, "testing", cl.Info().Name)
+	assert.Equal(t, Disabled, cl.Info().Status)
+}
+
+func TestCertificateLeafCreatesCorrectly(t *testing.T) {
+	c, _ := CreateConfigFromStrings(t, certificateLeaf)
+
+	cl, err := c.FindResource("certificate_leaf.testing")
+	assert.NoError(t, err)
+
+	assert.Equal(t, "testing", cl.Info().Name)
+	assert.Equal(t, TypeCertificateLeaf, cl.Info().Type)
+	assert.Equal(t, PendingCreation, cl.Info().Status)
+
+	assert.Equal(t, cl.(*CertificateLeaf).DNSNames[0], "1")
+	assert.Equal(t, cl.(*CertificateLeaf).DNSNames[1], "2")
+
+	assert.Equal(t, cl.(*CertificateLeaf).IPAddresses[0], "a")
+	assert.Equal(t, cl.(*CertificateLeaf).IPAddresses[1], "b")
+}
+
+func TestCertificateLeafDisabled(t *testing.T) {
+	c, _ := CreateConfigFromStrings(t, certificateLeafDisabled)
+
+	cl, err := c.FindResource("certificate_leaf.testing")
+	assert.NoError(t, err)
+
+	assert.Equal(t, "testing", cl.Info().Name)
+	assert.Equal(t, Disabled, cl.Info().Status)
+}
+
+const certificateCA = `
+certificate_ca "testing" {
+	output = "/"
+}
+`
+
+const certificateCADisabled = `
+certificate_ca "testing" {
+	disabled = true
+	output = "/"
+}
+`
+const certificateLeaf = `
+certificate_leaf "testing" {
+	ip_addresses = ["a","b"]
+	dns_names = ["1","2"]
+	output = "/"
+	ca_cert = "./file"
+	ca_key = "./file"
+}
+`
+
+const certificateLeafDisabled = `
+certificate_leaf "testing" {
+	ca_cert = "./file"
+	ca_key = "./file"
+	disabled = true
+	ip_addresses = ["a","b"]
+	dns_names = ["1","2"]
+	output = "/"
+}
+`

--- a/pkg/config/copy.go
+++ b/pkg/config/copy.go
@@ -1,0 +1,23 @@
+package config
+
+// TypeCopy copies files from one location to another
+const TypeCopy ResourceType = "copy"
+
+// Docs allows the running of a Docusaurus container which can be used for
+// online tutorials or documentation
+type Copy struct {
+	ResourceInfo `hcl:",remain" mapstructure:",squash"`
+
+	Depends []string `hcl:"depends_on,optional" json:"depends,omitempty"`
+
+	Source      string `hcl:"source" json:"source"`           // Source file, folder or glob
+	Destination string `hcl:"destination" json:"destination"` // Destination to write file or files to
+	Permissions string `hcl:"permissions" json:"permissions"` // Permissions 0777 to set for written file
+
+	CopiedFiles []string `json:"copied_files" mapstructure:"copied_files" state:"true"`
+}
+
+// NewCopy creates a new Copy config resource
+func NewCopy(name string) *Copy {
+	return &Copy{ResourceInfo: ResourceInfo{Name: name, Type: TypeCopy, Status: PendingCreation}}
+}

--- a/pkg/config/copy.go
+++ b/pkg/config/copy.go
@@ -10,9 +10,9 @@ type Copy struct {
 
 	Depends []string `hcl:"depends_on,optional" json:"depends,omitempty"`
 
-	Source      string `hcl:"source" json:"source"`           // Source file, folder or glob
-	Destination string `hcl:"destination" json:"destination"` // Destination to write file or files to
-	Permissions string `hcl:"permissions" json:"permissions"` // Permissions 0777 to set for written file
+	Source      string `hcl:"source" json:"source"`                              // Source file, folder or glob
+	Destination string `hcl:"destination" json:"destination"`                    // Destination to write file or files to
+	Permissions string `hcl:"permissions,optional" json:"permissions,omitempty"` // Permissions 0777 to set for written file
 
 	CopiedFiles []string `json:"copied_files" mapstructure:"copied_files" state:"true"`
 }

--- a/pkg/config/copyt_test.go
+++ b/pkg/config/copyt_test.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCreatesCopy(t *testing.T) {
+	c := NewCopy("abc")
+
+	assert.Equal(t, "abc", c.Name)
+	assert.Equal(t, TypeCopy, c.Type)
+}
+
+func TestCopyCreatesCorrectly(t *testing.T) {
+	c, _ := CreateConfigFromStrings(t, copy)
+
+	cl, err := c.FindResource("copy.testing")
+	assert.NoError(t, err)
+
+	assert.Equal(t, "testing", cl.Info().Name)
+	assert.Equal(t, TypeCopy, cl.Info().Type)
+	assert.Equal(t, PendingCreation, cl.Info().Status)
+
+	assert.Equal(t, "/", cl.(*Copy).Source)
+	assert.Equal(t, "/path", cl.(*Copy).Destination)
+	assert.Equal(t, "0700", cl.(*Copy).Permissions)
+}
+
+func TestCopyDisabled(t *testing.T) {
+	c, _ := CreateConfigFromStrings(t, copyDisabled)
+
+	cl, err := c.FindResource("copy.testing")
+	assert.NoError(t, err)
+
+	assert.Equal(t, "testing", cl.Info().Name)
+	assert.Equal(t, Disabled, cl.Info().Status)
+}
+
+const copy = `
+copy "testing" {
+	source = "/"
+	destination = "/path"
+	permissions = "0700"
+}
+`
+
+const copyDisabled = `
+copy "testing" {
+	disabled = true
+	source = "/"
+	destination = "/path"
+	permissions = "0700"
+}
+`

--- a/pkg/config/parse_test.go
+++ b/pkg/config/parse_test.go
@@ -489,7 +489,7 @@ func TestParseProcessesShipyardFunctions(t *testing.T) {
 	assert.Equal(t, os.Getenv("HOME"), cc.EnvVar["home"])
 	assert.Equal(t, utils.ShipyardHome(), cc.EnvVar["shipyard"])
 	assert.Contains(t, cc.EnvVar["file"], "version=\"consul:1.8.1\"")
-	assert.Equal(t, utils.GetDataFolder("mine"), cc.EnvVar["data"])
+	assert.Equal(t, utils.GetDataFolder("mine", os.ModePerm), cc.EnvVar["data"])
 	assert.Equal(t, utils.GetDockerIP(), cc.EnvVar["docker_ip"])
 	assert.Equal(t, utils.GetDockerHost(), cc.EnvVar["docker_host"])
 	assert.Equal(t, ip, cc.EnvVar["shipyard_ip"])

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -127,6 +127,12 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 			out = &Sidecar{}
 		case TypeTemplate:
 			out = &Template{}
+		case TypeCertificateCA:
+			out = &CertificateCA{}
+		case TypeCertificateLeaf:
+			out = &CertificateLeaf{}
+		case TypeCopy:
+			out = &Copy{}
 		case TypeVariable:
 			out = &Variable{}
 		default:

--- a/pkg/providers/certs.go
+++ b/pkg/providers/certs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/shipyard-run/connector/crypto"
 	"github.com/shipyard-run/shipyard/pkg/config"
+	"golang.org/x/xerrors"
 )
 
 type CertificateCA struct {
@@ -81,13 +82,13 @@ func (c *CertificateLeaf) Create() error {
 	ca := &crypto.X509{}
 	err := ca.ReadFile(c.config.CACert)
 	if err != nil {
-		return fmt.Errorf("Unable to read root certificate: %s", c.config.CACert)
+		return xerrors.Errorf("Unable to read root certificate %s: %w", c.config.CACert, err)
 	}
 
 	rk := crypto.NewKeyPair()
 	err = rk.Private.ReadFile(c.config.CAKey)
 	if err != nil {
-		return fmt.Errorf("Unable to read root certificate: %s", c.config.CAKey)
+		return xerrors.Errorf("Unable to read root key %s: %w", c.config.CAKey, err)
 	}
 
 	k, err := crypto.GenerateKeyPair()
@@ -113,12 +114,12 @@ func (c *CertificateLeaf) Destroy() error {
 
 	err := os.Remove(path.Join(c.config.Output, fmt.Sprintf("%s.key", c.config.Name)))
 	if err != nil {
-		return err
+		c.log.Info("Unable to remove key", "ref", c.config.Name, "error", err)
 	}
 
 	err = os.Remove(path.Join(c.config.Output, fmt.Sprintf("%s.cert", c.config.Name)))
 	if err != nil {
-		return err
+		c.log.Info("Unable to remove cert", "ref", c.config.Name, "error", err)
 	}
 
 	return nil

--- a/pkg/providers/certs.go
+++ b/pkg/providers/certs.go
@@ -1,0 +1,129 @@
+package providers
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/shipyard-run/connector/crypto"
+	"github.com/shipyard-run/shipyard/pkg/config"
+)
+
+type CertificateCA struct {
+	config *config.CertificateCA
+	log    hclog.Logger
+}
+
+type CertificateLeaf struct {
+	config *config.CertificateLeaf
+	log    hclog.Logger
+}
+
+func NewCertificateCA(co *config.CertificateCA, l hclog.Logger) *CertificateCA {
+	return &CertificateCA{co, l}
+}
+
+func NewCertificateLeaf(co *config.CertificateLeaf, l hclog.Logger) *CertificateLeaf {
+	return &CertificateLeaf{co, l}
+}
+
+func (c *CertificateCA) Create() error {
+	c.log.Info("Creating CA Certificate", "ref", c.config.Name)
+
+	k, err := crypto.GenerateKeyPair()
+	if err != nil {
+		return err
+	}
+
+	ca, err := crypto.GenerateCA(k.Private)
+	if err != nil {
+		return err
+	}
+
+	err = k.Private.WriteFile(path.Join(c.config.Output, fmt.Sprintf("%s.key", c.config.Name)))
+	if err != nil {
+		return err
+	}
+
+	err = ca.WriteFile(path.Join(c.config.Output, fmt.Sprintf("%s.cert", c.config.Name)))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *CertificateCA) Destroy() error {
+	c.log.Info("Destroy CA Certificate", "ref", c.config.Name)
+
+	err := os.Remove(path.Join(c.config.Output, fmt.Sprintf("%s.key", c.config.Name)))
+	if err != nil {
+		return err
+	}
+
+	err = os.Remove(path.Join(c.config.Output, fmt.Sprintf("%s.cert", c.config.Name)))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *CertificateCA) Lookup() ([]string, error) {
+	return nil, nil
+}
+
+func (c *CertificateLeaf) Create() error {
+	c.log.Info("Creating Leaf Certificate", "ref", c.config.Name)
+
+	// load the root key
+	ca := &crypto.X509{}
+	err := ca.ReadFile(c.config.CACert)
+	if err != nil {
+		return fmt.Errorf("Unable to read root certificate: %s", c.config.CACert)
+	}
+
+	rk := crypto.NewKeyPair()
+	err = rk.Private.ReadFile(c.config.CAKey)
+	if err != nil {
+		return fmt.Errorf("Unable to read root certificate: %s", c.config.CAKey)
+	}
+
+	k, err := crypto.GenerateKeyPair()
+	if err != nil {
+		return err
+	}
+
+	err = k.Private.WriteFile(path.Join(c.config.Output, fmt.Sprintf("%s.key", c.config.Name)))
+	if err != nil {
+		return err
+	}
+
+	lc, err := crypto.GenerateLeaf(c.config.IPAddresses, c.config.DNSNames, ca, rk.Private, k.Private)
+	if err != nil {
+		return err
+	}
+
+	return lc.WriteFile(path.Join(c.config.Output, fmt.Sprintf("%s.cert", c.config.Name)))
+}
+
+func (c *CertificateLeaf) Destroy() error {
+	c.log.Info("Destroy Leaf Certificate", "ref", c.config.Name)
+
+	err := os.Remove(path.Join(c.config.Output, fmt.Sprintf("%s.key", c.config.Name)))
+	if err != nil {
+		return err
+	}
+
+	err = os.Remove(path.Join(c.config.Output, fmt.Sprintf("%s.cert", c.config.Name)))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *CertificateLeaf) Lookup() ([]string, error) {
+	return nil, nil
+}

--- a/pkg/providers/certs_test.go
+++ b/pkg/providers/certs_test.go
@@ -1,0 +1,90 @@
+package providers
+
+import (
+	"fmt"
+	"path"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/shipyard-run/shipyard/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func setupCACert(t *testing.T) (*config.CertificateCA, *CertificateCA) {
+	dir := t.TempDir()
+
+	cc := config.NewCertificateCA("test")
+	cc.Output = dir
+
+	p := NewCertificateCA(cc, hclog.NewNullLogger())
+
+	return cc, p
+}
+
+func setupLeafCert(t *testing.T) (*config.CertificateLeaf, *CertificateLeaf) {
+	dir := t.TempDir()
+
+	cc := config.NewCertificateCA("root")
+	p := NewCertificateCA(cc, hclog.NewNullLogger())
+
+	cc.Output = dir
+	err := p.Create()
+	require.NoError(t, err)
+
+	cl := config.NewCertificateLeaf("test")
+	cl.Output = dir
+	cl.IPAddresses = []string{"127.0.0.1"}
+	cl.DNSNames = []string{"localhost"}
+	cl.CACert = path.Join(dir, "root.cert")
+	cl.CAKey = path.Join(dir, "root.key")
+
+	pl := NewCertificateLeaf(cl, hclog.NewNullLogger())
+
+	return cl, pl
+}
+
+func TestGeneratesValidCA(t *testing.T) {
+	c, p := setupCACert(t)
+
+	err := p.Create()
+	require.NoError(t, err)
+
+	require.FileExists(t, path.Join(c.Output, fmt.Sprintf("%s.cert", c.Name)))
+	require.FileExists(t, path.Join(c.Output, fmt.Sprintf("%s.key", c.Name)))
+}
+
+func TestDestroyCleansUpCA(t *testing.T) {
+	c, p := setupCACert(t)
+
+	err := p.Create()
+	require.NoError(t, err)
+
+	err = p.Destroy()
+	require.NoError(t, err)
+
+	require.NoFileExists(t, path.Join(c.Output, fmt.Sprintf("%s.cert", c.Name)))
+	require.NoFileExists(t, path.Join(c.Output, fmt.Sprintf("%s.key", c.Name)))
+}
+
+func TestGeneratesValidLeaf(t *testing.T) {
+	c, p := setupLeafCert(t)
+
+	err := p.Create()
+	require.NoError(t, err)
+
+	require.FileExists(t, path.Join(c.Output, fmt.Sprintf("%s.cert", c.Name)))
+	require.FileExists(t, path.Join(c.Output, fmt.Sprintf("%s.key", c.Name)))
+}
+
+func TestDestroyCleansUpLeaf(t *testing.T) {
+	c, p := setupLeafCert(t)
+
+	err := p.Create()
+	require.NoError(t, err)
+
+	err = p.Destroy()
+	require.NoError(t, err)
+
+	require.NoFileExists(t, path.Join(c.Output, fmt.Sprintf("%s.cert", c.Name)))
+	require.NoFileExists(t, path.Join(c.Output, fmt.Sprintf("%s.key", c.Name)))
+}

--- a/pkg/providers/copy.go
+++ b/pkg/providers/copy.go
@@ -69,11 +69,15 @@ func (c *Copy) Destroy() error {
 	c.log.Info("Destroy Copy", "ref", c.config.Name)
 
 	for _, f := range c.config.CopiedFiles {
-		fn := strings.Replace(f, c.config.Source, c.config.Destination, 1)
-		c.log.Debug("Remove file", "ref", c.config.Name, "file", fn)
-		err := os.Remove(fn)
-		if err != nil {
-			c.log.Debug("Unable to remove file", "ref", c.config.Name, "file", fn)
+		fn := strings.Replace(f, c.config.Source, c.config.Destination, -1)
+		c.log.Debug("Remove file", "ref", c.config.Name, "file", fn, "source", c.config.Source, "destination", c.config.Destination)
+
+		// double check that the replacement has worked, we do not want to remove the original
+		if fn != f {
+			err := os.RemoveAll(fn)
+			if err != nil {
+				c.log.Debug("Unable to remove file", "ref", c.config.Name, "file", fn)
+			}
 		}
 	}
 

--- a/pkg/providers/copy.go
+++ b/pkg/providers/copy.go
@@ -1,0 +1,85 @@
+package providers
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-hclog"
+	cp "github.com/otiai10/copy"
+	"github.com/shipyard-run/shipyard/pkg/config"
+	"golang.org/x/xerrors"
+)
+
+type Copy struct {
+	log    hclog.Logger
+	config *config.Copy
+}
+
+func NewCopy(co *config.Copy, l hclog.Logger) *Copy {
+	return &Copy{l, co}
+}
+
+func (c *Copy) Create() error {
+	c.log.Info("Creating Copy", "ref", c.config.Name, "source", c.config.Source, "destination", c.config.Destination, "perms", c.config.Permissions)
+
+	// Check source exists
+	_, err := os.Stat(c.config.Source)
+	if err != nil {
+		c.log.Debug("Error discovering source directory", "ref", c.config.Name, "source", c.config.Source, "error", err)
+		return xerrors.Errorf("unable to find source directory for copy resource, ref=%s: %w", c.config.Name, err)
+	}
+
+	//
+	opts := cp.Options{}
+	opts.Sync = true
+
+	// keep track of
+	files := []string{}
+	opts.Skip = func(file string) (bool, error) {
+		c.log.Debug("Copy file", "ref", c.config.Name, "file", file)
+
+		files = append(files, file)
+		return false, nil
+	}
+
+	if c.config.Permissions != "" {
+		perms, err := strconv.ParseInt(c.config.Permissions, 8, 64)
+		if err != nil {
+			c.log.Debug("Invalid destination permissions", "ref", c.config.Name, "permissions", c.config.Permissions, "error", err)
+			return xerrors.Errorf("Invalid destination permissions for copy resource, ref=%s %s: %w", c.config.Name, c.config.Permissions, err)
+		}
+
+		opts.AddPermission = os.FileMode(perms)
+	}
+
+	err = cp.Copy(c.config.Source, c.config.Destination, opts)
+	if err != nil {
+		c.log.Debug("Error copying source directory", "ref", c.config.Name, "source", c.config.Source, "error", err)
+
+		return xerrors.Errorf("unable to copy files, ref=%s: %w", c.config.Name, err)
+	}
+
+	c.config.CopiedFiles = files
+
+	return nil
+}
+
+func (c *Copy) Destroy() error {
+	c.log.Info("Destroy Copy", "ref", c.config.Name)
+
+	for _, f := range c.config.CopiedFiles {
+		fn := strings.Replace(f, c.config.Source, c.config.Destination, 1)
+		c.log.Debug("Remove file", "ref", c.config.Name, "file", fn)
+		err := os.Remove(fn)
+		if err != nil {
+			c.log.Debug("Unable to remove file", "ref", c.config.Name, "file", fn)
+		}
+	}
+
+	return nil
+}
+
+func (c *Copy) Lookup() ([]string, error) {
+	return nil, nil
+}

--- a/pkg/providers/copy_test.go
+++ b/pkg/providers/copy_test.go
@@ -1,0 +1,94 @@
+package providers
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/shipyard-run/shipyard/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func setupCopy(t *testing.T) (*config.Copy, *Copy) {
+	dir := t.TempDir()
+	inDir := path.Join(dir, "in")
+	outDir := path.Join(dir, "out")
+
+	// add a child dir
+	err := os.Mkdir(inDir, 0775)
+	require.NoError(t, err)
+
+	// add some example files
+	ioutil.WriteFile(path.Join(inDir, "file1.txt"), []byte("data"), 0755)
+	ioutil.WriteFile(path.Join(inDir, "file2.txt"), []byte("data"), 0755)
+
+	cc := config.NewCopy("tests")
+	cc.Source = inDir
+	cc.Destination = outDir
+
+	p := NewCopy(cc, hclog.New(&hclog.LoggerOptions{Level: hclog.Debug}))
+
+	return cc, p
+}
+
+func TestCopiesADirectory(t *testing.T) {
+	c, p := setupCopy(t)
+
+	err := p.Create()
+	require.NoError(t, err)
+
+	// check the destination
+	require.DirExists(t, c.Destination)
+
+	// check the files
+	require.FileExists(t, path.Join(c.Destination, "file1.txt"))
+	require.FileExists(t, path.Join(c.Destination, "file2.txt"))
+}
+
+func TestCopiesASingleFile(t *testing.T) {
+	c, p := setupCopy(t)
+
+	dDir := c.Destination
+	c.Source = path.Join(c.Source, "file1.txt")
+	c.Destination = path.Join(c.Destination, "file1.txt")
+
+	err := p.Create()
+	require.NoError(t, err)
+
+	// check the files
+	require.FileExists(t, path.Join(dDir, "file1.txt"))
+	require.NoFileExists(t, path.Join(dDir, "file2.txt"))
+}
+
+func TestCopiesADirectoryWithPermissions(t *testing.T) {
+	c, p := setupCopy(t)
+	c.Permissions = "0777"
+
+	err := p.Create()
+	require.NoError(t, err)
+
+	// check the destination
+	require.DirExists(t, c.Destination)
+
+	// check the files
+	require.FileExists(t, path.Join(c.Destination, "file1.txt"))
+	require.FileExists(t, path.Join(c.Destination, "file2.txt"))
+
+	fs, _ := os.Stat(path.Join(c.Destination, "file1.txt"))
+	require.Equal(t, os.FileMode(0777), fs.Mode())
+}
+
+func TestRemovesFiles(t *testing.T) {
+	c, p := setupCopy(t)
+
+	err := p.Create()
+	require.NoError(t, err)
+
+	err = p.Destroy()
+	require.NoError(t, err)
+
+	require.NoFileExists(t, path.Join(c.Destination, "file1.txt"))
+	require.NoFileExists(t, path.Join(c.Destination, "file2.txt"))
+}

--- a/pkg/shipyard/engine.go
+++ b/pkg/shipyard/engine.go
@@ -477,6 +477,12 @@ func generateProviderImpl(c config.Resource, cc *Clients) providers.Provider {
 		return providers.NewNull(c.Info(), cc.Logger)
 	case config.TypeTemplate:
 		return providers.NewTemplate(c.(*config.Template), cc.Logger)
+	case config.TypeCertificateCA:
+		return providers.NewCertificateCA(c.(*config.CertificateCA), cc.Logger)
+	case config.TypeCertificateLeaf:
+		return providers.NewCertificateLeaf(c.(*config.CertificateLeaf), cc.Logger)
+	case config.TypeCopy:
+		return providers.NewCopy(c.(*config.Copy), cc.Logger)
 	}
 
 	return nil

--- a/pkg/utils/util_test.go
+++ b/pkg/utils/util_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -244,11 +245,13 @@ func TestShipyardDataReturnsPath(t *testing.T) {
 		os.RemoveAll(tmp)
 	})
 
-	d := GetDataFolder("test")
+	d := GetDataFolder("test", 0775)
 
 	assert.Equal(t, filepath.Join(tmp, ".shipyard", "/data", "/test"), d)
 
 	s, err := os.Stat(d)
+	fmt.Println(d, s)
+
 	assert.NoError(t, err)
 	assert.True(t, s.IsDir())
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -296,10 +296,13 @@ func GetReleasesFolder() string {
 }
 
 // GetDataFolder creates the data directory used by the application
-func GetDataFolder(p string) string {
+func GetDataFolder(p string, perms os.FileMode) string {
 	data := filepath.Join(ShipyardHome(), "data", p)
+
 	// create the folder if it does not exist
-	os.MkdirAll(data, os.ModePerm)
+	os.MkdirAll(data, perms)
+	os.Chmod(data, perms)
+
 	return data
 }
 


### PR DESCRIPTION
## version v0.4.0
* Add new resource to enable copying resources

```hcl
copy "testing" {
	source = "/"
	destination = "/path"
	permissions = "0700"
}
```

* Add new resource to enable generation of certificates

```hcl
certificate_ca "testing" {
	output = "/"
}
certificate_leaf "testing" {
	ip_addresses = ["a","b"]
	dns_names = ["1","2"]
	ca_cert = "./file"
	ca_key = "./file"
	output = "/"
}
```

* Add new function to allow the creation of data directories with specific permissions

```hcl
data_with_permissions("name","0777")
```