### PR TITLE
Update Nomad, K3s

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## version v0.4.13
+* Update Nomad version to 1.4.0
+* Add capability to run K3s clusters when the Docker engine is not using overlay or overlay2
+
 ## version v0.4.0
 * Add new resource to enable copying resources
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## version v0.4.13
 * Update Nomad version to 1.4.0
+* Update K3s to v1.23.12
 * Add capability to run K3s clusters when the Docker engine is not using overlay or overlay2
 
 ## version v0.4.0

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/pkg/ioutils"
-	"github.com/shipyard-run/shipyard/pkg/clients/mocks"
+	"github.com/shipyard-run/shipyard/pkg/clients"
 	"github.com/shipyard-run/shipyard/pkg/config"
 	"github.com/shipyard-run/shipyard/pkg/utils"
 	"github.com/spf13/cobra"
@@ -44,8 +44,8 @@ func setupState(state string) func() {
 	}
 }
 
-func setupExec(state string) (*cobra.Command, *mocks.MockContainerTasks, func()) {
-	mt := &mocks.MockContainerTasks{}
+func setupExec(state string) (*cobra.Command, *clients.MockContainerTasks, func()) {
+	mt := &clients.MockContainerTasks{}
 	mt.On("FindContainerIDs", mock.Anything, mock.Anything).Return([]string{"abc"}, nil)
 	mt.On("CreateShell", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mt.On("CreateContainer", mock.Anything).Return("123", nil)

--- a/cmd/push_test.go
+++ b/cmd/push_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func setupPush(state string) (*cobra.Command, *mocks.MockContainerTasks, func()) {
-	mt := &mocks.MockContainerTasks{}
+func setupPush(state string) (*cobra.Command, *clients.MockContainerTasks, func()) {
+	mt := &clients.MockContainerTasks{}
 	mt.On("FindContainerIDs", mock.Anything, mock.Anything).Return([]string{"abc"}, nil)
 	mt.On("PullImage", mock.Anything, false).Return(nil)
 	mt.On("CopyLocalDockerImagesToVolume", mock.Anything, mock.Anything, mock.Anything).Return([]string{"/images/file.tar"}, nil)

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -45,7 +45,7 @@ func setupRun(t *testing.T, timeout string) (*cobra.Command, *runMocks) {
 	mockSystem.On("PromptInput", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("")
 	mockSystem.On("CheckVersion", mock.Anything).Return("", false)
 
-	mockTasks := &clientmocks.MockContainerTasks{}
+	mockTasks := &clients.MockContainerTasks{}
 	mockTasks.On("SetForcePull", mock.Anything)
 
 	mockConnector := &clients.ConnectorMock{}

--- a/pkg/clients/container_tasks.go
+++ b/pkg/clients/container_tasks.go
@@ -76,4 +76,16 @@ type ContainerTasks interface {
 
 	// CreateShell in the running container and attach
 	CreateShell(id string, command []string, stdin io.ReadCloser, stdout io.Writer, stderr io.Writer) error
+
+  // Returns basic information related to the Docker Engine
+  EngineInfo() *EngineInfo
 }
+
+type EngineInfo struct {
+  // StorageDriver used by the engine, overlay, devicemapper, etc
+  StorageDriver string
+
+  // EngineType, docker, podman, not found
+  EngineType string
+}
+

--- a/pkg/clients/container_tasks_mocks.go
+++ b/pkg/clients/container_tasks_mocks.go
@@ -1,4 +1,4 @@
-package mocks
+package clients
 
 import (
 	"io"
@@ -136,4 +136,14 @@ func (d *MockContainerTasks) CreateShell(id string, command []string, stdin io.R
 	args := d.Called(id, command, stdin, stdout, stderr)
 
 	return args.Error(0)
+}
+
+func (d*MockContainerTasks) EngineInfo() *EngineInfo {
+  args := d.Called()
+
+  if ei,ok := args.Get(0).(*EngineInfo); ok {
+    return ei
+  }
+
+  return nil
 }

--- a/pkg/clients/docker.go
+++ b/pkg/clients/docker.go
@@ -24,6 +24,7 @@ type Docker interface {
 		platform *specs.Platform,
 		containerName string,
 	) (container.ContainerCreateCreatedBody, error)
+
 	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
 	ContainerStart(context.Context, string, types.ContainerStartOptions) error
 	ContainerStop(ctx context.Context, containerID string, timeout *time.Duration) error
@@ -56,6 +57,7 @@ type Docker interface {
 	ImageBuild(ctx context.Context, buildContext io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error)
 
 	ServerVersion(ctx context.Context) (types.Version, error)
+  Info(ctx context.Context) (types.Info, error)
 }
 
 // NewDocker creates a new Docker client

--- a/pkg/clients/docker_tasks_command_shell_test.go
+++ b/pkg/clients/docker_tasks_command_shell_test.go
@@ -27,6 +27,8 @@ func setupShellMocks() (*DockerTasks, *clients.MockDocker) {
 		}, nil)
 	md.On("ContainerExecInspect", mock.Anything, mock.Anything).Return(types.ContainerExecInspect{ExitCode: 0}, nil)
 
+  md.On("Info", mock.Anything).Return(types.Info{Driver: StorageDriverOverlay2}, nil)
+
 	mic := &clients.ImageLog{}
 	mic.On("Log", mock.Anything, mock.Anything).Return(nil)
 

--- a/pkg/clients/docker_tasks_container_build_test.go
+++ b/pkg/clients/docker_tasks_container_build_test.go
@@ -27,6 +27,7 @@ func testBuildMockSetup() *mocks.MockDocker {
 			Body: ioutil.NopCloser(strings.NewReader("")),
 		}, nil)
 
+  mk.On("Info", mock.Anything).Return(types.Info{Driver: StorageDriverOverlay2}, nil)
 	return mk
 }
 

--- a/pkg/clients/docker_tasks_container_create_test.go
+++ b/pkg/clients/docker_tasks_container_create_test.go
@@ -117,6 +117,8 @@ func setupContainerMocks() (*clients.MockDocker, *clients.ImageLog) {
 	md.On("VolumeList", mock.Anything, mock.Anything).Return(nil, nil)
 	md.On("VolumeCreate", mock.Anything, mock.Anything).Return(types.Volume{Name: "test_volume"}, nil)
 	md.On("VolumeRemove", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+  
+  md.On("Info", mock.Anything).Return(types.Info{Driver: StorageDriverOverlay2}, nil)
 
 	mic := &clients.ImageLog{}
 	mic.On("Log", mock.Anything, mock.Anything).Return(nil)

--- a/pkg/clients/docker_tasks_container_logs_test.go
+++ b/pkg/clients/docker_tasks_container_logs_test.go
@@ -20,6 +20,9 @@ func TestContainerLogsCalled(t *testing.T) {
 		ioutil.NopCloser(bytes.NewBufferString("test")),
 		fmt.Errorf("boom"),
 	)
+
+  md.On("Info", mock.Anything).Return(types.Info{Driver: StorageDriverOverlay2}, nil)
+
 	mic := &mocks.ImageLog{}
 
 	dt := NewDockerTasks(md, mic, &TarGz{}, hclog.NewNullLogger())

--- a/pkg/clients/docker_tasks_container_remove_test.go
+++ b/pkg/clients/docker_tasks_container_remove_test.go
@@ -14,6 +14,7 @@ import (
 func TestContainerRemoveCallsRemoveGently(t *testing.T) {
 	md := &mocks.MockDocker{}
 	md.On("ServerVersion", mock.Anything).Return(types.Version{}, nil)
+  md.On("Info", mock.Anything).Return(types.Info{Driver: StorageDriverOverlay2}, nil)
 
 	mic := &clients.ImageLog{}
 	dt := NewDockerTasks(md, mic, &TarGz{}, hclog.NewNullLogger())
@@ -30,6 +31,7 @@ func TestContainerRemoveCallsRemoveGently(t *testing.T) {
 func TestContainerRemoveCallsRemoveGentlyOnStopFailForces(t *testing.T) {
 	md := &mocks.MockDocker{}
 	md.On("ServerVersion", mock.Anything).Return(types.Version{}, nil)
+  md.On("Info", mock.Anything).Return(types.Info{Driver: StorageDriverOverlay2}, nil)
 
 	mic := &clients.ImageLog{}
 	dt := NewDockerTasks(md, mic, &TarGz{}, hclog.NewNullLogger())
@@ -46,6 +48,7 @@ func TestContainerRemoveCallsRemoveGentlyOnStopFailForces(t *testing.T) {
 func TestContainerRemoveCallsRemoveGentlyOnRemoveFailForces(t *testing.T) {
 	md := &mocks.MockDocker{}
 	md.On("ServerVersion", mock.Anything).Return(types.Version{}, nil)
+  md.On("Info", mock.Anything).Return(types.Info{Driver: StorageDriverOverlay2}, nil)
 
 	mic := &clients.ImageLog{}
 	dt := NewDockerTasks(md, mic, &TarGz{}, hclog.NewNullLogger())
@@ -63,6 +66,7 @@ func TestContainerRemoveCallsRemoveGentlyOnRemoveFailForces(t *testing.T) {
 func TestContainerRemoveFailsCallsRemoveForcefully(t *testing.T) {
 	md := &mocks.MockDocker{}
 	md.On("ServerVersion", mock.Anything).Return(types.Version{}, nil)
+  md.On("Info", mock.Anything).Return(types.Info{Driver: StorageDriverOverlay2}, nil)
 
 	mic := &clients.ImageLog{}
 	dt := NewDockerTasks(md, mic, &TarGz{}, hclog.NewNullLogger())

--- a/pkg/clients/docker_tasks_copy_from_container_test.go
+++ b/pkg/clients/docker_tasks_copy_from_container_test.go
@@ -23,6 +23,7 @@ func TestCopyFromContainerCopiesFile(t *testing.T) {
 
 	md := &mocks.MockDocker{}
 	md.On("ServerVersion", mock.Anything).Return(types.Version{}, nil)
+  md.On("Info", mock.Anything).Return(types.Info{Driver: StorageDriverOverlay2}, nil)
 
 	mic := &clients.ImageLog{}
 	md.On("CopyFromContainer", mock.Anything, id, src).Return(
@@ -50,6 +51,7 @@ func TestCopyFromContainerReturnsErrorOnDockerError(t *testing.T) {
 
 	md := &mocks.MockDocker{}
 	md.On("ServerVersion", mock.Anything).Return(types.Version{}, nil)
+  md.On("Info", mock.Anything).Return(types.Info{Driver: StorageDriverOverlay2}, nil)
 
 	mic := &clients.ImageLog{}
 	md.On("CopyFromContainer", mock.Anything, id, src).Return(

--- a/pkg/clients/docker_tasks_copy_to_volume_test.go
+++ b/pkg/clients/docker_tasks_copy_to_volume_test.go
@@ -27,6 +27,7 @@ var testCopyLocalVolume = "images"
 func testCreateCopyLocalMocks() *mocks.MockDocker {
 	mk := &mocks.MockDocker{}
 	mk.On("ServerVersion", mock.Anything).Return(types.Version{}, nil)
+  mk.On("Info", mock.Anything).Return(types.Info{Driver: StorageDriverOverlay2}, nil)
 	mk.On("ContainerInspect", mock.Anything, mock.Anything).Return(
 		types.ContainerJSON{
 			&types.ContainerJSONBase{State: &types.ContainerState{Running: true}},

--- a/pkg/clients/docker_tasks_execute_command_test.go
+++ b/pkg/clients/docker_tasks_execute_command_test.go
@@ -22,6 +22,7 @@ func testExecCommandMockSetup() (*mocks.MockDocker, *mocks.ImageLog) {
 
 	mk := &mocks.MockDocker{}
 	mk.On("ServerVersion", mock.Anything).Return(types.Version{}, nil)
+  mk.On("Info", mock.Anything).Return(types.Info{Driver: StorageDriverOverlay2}, nil)
 	mk.On("ContainerExecCreate", mock.Anything, mock.Anything, mock.Anything).Return(types.IDResponse{ID: "abc"}, nil)
 	mk.On("ContainerExecAttach", mock.Anything, mock.Anything, mock.Anything).Return(
 		types.HijackedResponse{

--- a/pkg/clients/docker_tasks_find_ids_test.go
+++ b/pkg/clients/docker_tasks_find_ids_test.go
@@ -14,6 +14,7 @@ import (
 func TestFindContainerIDsReturnsID(t *testing.T) {
 	md := &mocks.MockDocker{}
 	md.On("ServerVersion", mock.Anything).Return(types.Version{}, nil)
+  md.On("Info", mock.Anything).Return(types.Info{Driver: StorageDriverOverlay2}, nil)
 	md.On("ContainerList", mock.Anything, mock.Anything).Return(
 		[]types.Container{
 			types.Container{ID: "abc"},
@@ -43,6 +44,7 @@ func TestFindContainerIDsReturnsID(t *testing.T) {
 func TestFindContainerIDsReturnsErrorWhenDockerFail(t *testing.T) {
 	md := &mocks.MockDocker{}
 	md.On("ServerVersion", mock.Anything).Return(types.Version{}, nil)
+  md.On("Info", mock.Anything).Return(types.Info{Driver: StorageDriverOverlay2}, nil)
 	md.On("ContainerList", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
 
 	dt := NewDockerTasks(md, nil, &TarGz{}, hclog.NewNullLogger())
@@ -54,6 +56,7 @@ func TestFindContainerIDsReturnsErrorWhenDockerFail(t *testing.T) {
 func TestFindContainerIDsReturnsNilWhenNoIDs(t *testing.T) {
 	md := &mocks.MockDocker{}
 	md.On("ServerVersion", mock.Anything).Return(types.Version{}, nil)
+  md.On("Info", mock.Anything).Return(types.Info{Driver: StorageDriverOverlay2}, nil)
 	md.On("ContainerList", mock.Anything, mock.Anything).Return(nil, nil)
 
 	dt := NewDockerTasks(md, nil, &TarGz{}, hclog.NewNullLogger())
@@ -66,6 +69,7 @@ func TestFindContainerIDsReturnsNilWhenNoIDs(t *testing.T) {
 func TestFindContainerIDsReturnsNilWhenEmpty(t *testing.T) {
 	md := &mocks.MockDocker{}
 	md.On("ServerVersion", mock.Anything).Return(types.Version{}, nil)
+  md.On("Info", mock.Anything).Return(types.Info{Driver: StorageDriverOverlay2}, nil)
 	md.On("ContainerList", mock.Anything, mock.Anything).Return([]types.Container{}, nil)
 
 	dt := NewDockerTasks(md, nil, &TarGz{}, hclog.NewNullLogger())

--- a/pkg/clients/docker_tasks_image_pull_test.go
+++ b/pkg/clients/docker_tasks_image_pull_test.go
@@ -18,6 +18,7 @@ import (
 func setupImagePullMocks() (*mocks.MockDocker, *mocks.ImageLog) {
 	md := &mocks.MockDocker{}
 	md.On("ServerVersion", mock.Anything).Return(types.Version{}, nil)
+  md.On("Info", mock.Anything).Return(types.Info{Driver: StorageDriverOverlay2}, nil)
 	md.On("ImageList", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 	md.On("ImagePull", mock.Anything, mock.Anything, mock.Anything).Return(
 		ioutil.NopCloser(strings.NewReader("hello world")),

--- a/pkg/clients/mocks/docker.go
+++ b/pkg/clients/mocks/docker.go
@@ -262,3 +262,13 @@ func (m *MockDocker) ServerVersion(ctx context.Context) (types.Version, error) {
 
 	return types.Version{}, args.Error(1)
 }
+
+func (m *MockDocker) Info(ctx context.Context) (types.Info, error) {
+  args := m.Called(ctx)
+
+  if info,ok := args.Get(0).(types.Info); ok {
+    return info, args.Error(1)
+  }
+
+  return types.Info{}, args.Error(1)
+}

--- a/pkg/clients/system.go
+++ b/pkg/clients/system.go
@@ -190,7 +190,7 @@ func checkDocker() error {
 
 	// check that the server is a docker engine not podman
 	// if Docker there will be a component cEngine"
-	if dt.EngineType != EngineTypeDocker {
+	if dt.EngineInfo().EngineType != EngineTypeDocker {
 		return fmt.Errorf("Platform is not Docker")
 	}
 
@@ -211,7 +211,7 @@ func checkPodman() error {
 
 	// check that the server is a docker engine not podman
 	// if Docker there will be a component called "Engine"
-	if dt.EngineType != EngineTypePodman {
+	if dt.EngineInfo().EngineType != EngineTypePodman {
 		return fmt.Errorf("Platform is not Podman")
 	}
 

--- a/pkg/config/nomad_cluster.go
+++ b/pkg/config/nomad_cluster.go
@@ -22,6 +22,9 @@ type NomadCluster struct {
 	ConsulConfig  string   `hcl:"consul_config,optional" json:"consul_config,omitempty" mapstructure:"consul_config"`
 	Volumes       []Volume `hcl:"volume,block" json:"volumes,omitempty"`                                                    // volumes to attach to the cluster
 	OpenInBrowser bool     `hcl:"open_in_browser,optional" json:"open_in_browser,omitempty" mapstructure:"open_in_browser"` // open the UI in the browser after creation
+
+	ServerIPAddress string   `hcl:"server_ip_address,optional" json:"server_ip_address,omitempty" mapstructure:"server_ip_address"`
+	ClientIPAddress []string `hcl:"client_ip_address,optional" json:"client_ip_address,omitempty" mapstructure:"client_ip_address"`
 }
 
 // NewCluster creates new Cluster config with the correct defaults

--- a/pkg/providers/cluster_k3s.go
+++ b/pkg/providers/cluster_k3s.go
@@ -24,7 +24,7 @@ import (
 // https://github.com/rancher/k3d/blob/master/cli/commands.go
 
 const k3sBaseImage = "shipyardrun/k3s"
-const k3sBaseVersion = "v1.22.4"
+const k3sBaseVersion = "v1.23.12"
 
 var startTimeout = (300 * time.Second)
 

--- a/pkg/providers/cluster_nomad.go
+++ b/pkg/providers/cluster_nomad.go
@@ -17,7 +17,7 @@ import (
 )
 
 const nomadBaseImage = "shipyardrun/nomad"
-const nomadBaseVersion = "1.3.1"
+const nomadBaseVersion = "1.4.0"
 
 const dataDir = `
 data_dir = "/var/lib/nomad"

--- a/pkg/providers/cluster_nomad_test.go
+++ b/pkg/providers/cluster_nomad_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 
 	"github.com/mohae/deepcopy"
+	"github.com/shipyard-run/shipyard/pkg/clients"
 	"github.com/shipyard-run/shipyard/pkg/clients/mocks"
 	"github.com/shipyard-run/shipyard/pkg/config"
 	"github.com/shipyard-run/shipyard/pkg/utils"
@@ -21,9 +22,9 @@ import (
 )
 
 // setupClusterMocks sets up a happy path for mocks
-func setupNomadClusterMocks(t *testing.T) (*config.NomadCluster, *mocks.MockContainerTasks, *mocks.MockNomad) {
+func setupNomadClusterMocks(t *testing.T) (*config.NomadCluster, *clients.MockContainerTasks, *mocks.MockNomad) {
 
-	md := &mocks.MockContainerTasks{}
+	md := &clients.MockContainerTasks{}
 	md.On("FindContainerIDs", mock.Anything, mock.Anything).Return([]string{}, nil)
 	md.On("PullImage", mock.Anything, mock.Anything).Return(nil)
 	md.On("CreateVolume", mock.Anything, mock.Anything).Return("123", nil)
@@ -67,7 +68,7 @@ func setupNomadClusterMocks(t *testing.T) (*config.NomadCluster, *mocks.MockCont
 }
 
 func TestClusterNomadErrorsWhenUnableToLookupIDs(t *testing.T) {
-	md := &mocks.MockContainerTasks{}
+	md := &clients.MockContainerTasks{}
 	md.On("FindContainerIDs", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
 
 	p := NewNomadCluster(clusterNomadConfig, md, nil, hclog.NewNullLogger())
@@ -77,7 +78,7 @@ func TestClusterNomadErrorsWhenUnableToLookupIDs(t *testing.T) {
 }
 
 func TestClusterNomadErrorsWhenClusterExists(t *testing.T) {
-	md := &mocks.MockContainerTasks{}
+	md := &clients.MockContainerTasks{}
 	md.On("FindContainerIDs", "server."+clusterNomadConfig.Name, mock.Anything).Return([]string{"abc"}, nil)
 
 	p := NewNomadCluster(clusterNomadConfig, md, nil, hclog.NewNullLogger())

--- a/pkg/providers/container_test.go
+++ b/pkg/providers/container_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/shipyard-run/shipyard/pkg/clients"
 	"github.com/shipyard-run/shipyard/pkg/clients/mocks"
 	"github.com/shipyard-run/shipyard/pkg/config"
 	"github.com/stretchr/testify/mock"
@@ -15,7 +16,7 @@ import (
 func TestContainerCreatesSuccessfully(t *testing.T) {
 	cc := config.NewContainer("tests")
 	cc.Image = &config.Image{}
-	md := &mocks.MockContainerTasks{}
+	md := &clients.MockContainerTasks{}
 	hc := &mocks.MockHTTP{}
 	c := NewContainer(cc, md, hc, hclog.NewNullLogger())
 
@@ -32,7 +33,7 @@ func TestContainerCreatesSuccessfully(t *testing.T) {
 }
 
 func TestContainerSidecarCreatesContainerSuccessfully(t *testing.T) {
-	md := &mocks.MockContainerTasks{}
+	md := &clients.MockContainerTasks{}
 	hc := &mocks.MockHTTP{}
 
 	cc := config.NewSidecar("test")
@@ -81,7 +82,7 @@ func TestContainerRunsHTTPChecks(t *testing.T) {
 		HTTP:    "http://localhost:8500",
 	}
 
-	md := &mocks.MockContainerTasks{}
+	md := &clients.MockContainerTasks{}
 	hc := &mocks.MockHTTP{}
 	c := NewContainer(cc, md, hc, hclog.NewNullLogger())
 
@@ -105,7 +106,7 @@ func TestContainerRunsHTTPChecksWithCustomStatusCodes(t *testing.T) {
 		HTTPSuccessCodes: []int{200, 429},
 	}
 
-	md := &mocks.MockContainerTasks{}
+	md := &clients.MockContainerTasks{}
 	hc := &mocks.MockHTTP{}
 	c := NewContainer(cc, md, hc, hclog.NewNullLogger())
 
@@ -123,7 +124,7 @@ func TestContainerRunsHTTPChecksWithCustomStatusCodes(t *testing.T) {
 func TestContainerDoesNOTCreateWhenPullImageFail(t *testing.T) {
 	cc := config.NewContainer("tests")
 	cc.Image = &config.Image{}
-	md := &mocks.MockContainerTasks{}
+	md := &clients.MockContainerTasks{}
 	hc := &mocks.MockHTTP{}
 	c := NewContainer(cc, md, hc, hclog.NewNullLogger())
 
@@ -141,7 +142,7 @@ func TestContainerDoesNOTCreateWhenPullImageFail(t *testing.T) {
 func TestContainerDestroysCorrectlyWhenContainerExists(t *testing.T) {
 	cc := config.NewContainer("tests")
 	cc.Networks = []config.NetworkAttachment{config.NetworkAttachment{Name: "cloud"}}
-	md := &mocks.MockContainerTasks{}
+	md := &clients.MockContainerTasks{}
 	hc := &mocks.MockHTTP{}
 	c := NewContainer(cc, md, hc, hclog.NewNullLogger())
 
@@ -156,7 +157,7 @@ func TestContainerDestroysCorrectlyWhenContainerExists(t *testing.T) {
 func TestContainerDoesNotDestroysWhenNotExists(t *testing.T) {
 	cc := config.NewContainer("tests")
 	cc.Networks = []config.NetworkAttachment{config.NetworkAttachment{Name: "cloud"}}
-	md := &mocks.MockContainerTasks{}
+	md := &clients.MockContainerTasks{}
 	hc := &mocks.MockHTTP{}
 	c := NewContainer(cc, md, hc, hclog.NewNullLogger())
 
@@ -170,7 +171,7 @@ func TestContainerDoesNotDestroysWhenNotExists(t *testing.T) {
 func TestContainerDoesNotDestroysWhenLookupError(t *testing.T) {
 	cc := config.NewContainer("tests")
 	cc.Networks = []config.NetworkAttachment{config.NetworkAttachment{Name: "cloud"}}
-	md := &mocks.MockContainerTasks{}
+	md := &clients.MockContainerTasks{}
 	hc := &mocks.MockHTTP{}
 	c := NewContainer(cc, md, hc, hclog.NewNullLogger())
 
@@ -184,7 +185,7 @@ func TestContainerDoesNotDestroysWhenLookupError(t *testing.T) {
 func TestContainerLooksupIDs(t *testing.T) {
 	cc := config.NewContainer("tests")
 	cc.Networks = []config.NetworkAttachment{config.NetworkAttachment{Name: "cloud"}}
-	md := &mocks.MockContainerTasks{}
+	md := &clients.MockContainerTasks{}
 	hc := &mocks.MockHTTP{}
 	c := NewContainer(cc, md, hc, hclog.NewNullLogger())
 
@@ -199,7 +200,7 @@ func TestContainerBuildsContainer(t *testing.T) {
 	cc := config.NewContainer("tests")
 	cc.Build = &config.Build{Context: "./", File: "./"}
 
-	md := &mocks.MockContainerTasks{}
+	md := &clients.MockContainerTasks{}
 	md.On("BuildContainer", mock.Anything, mock.Anything).Return("testimage", nil)
 	md.On("CreateContainer", cc).Once().Return("", nil)
 

--- a/pkg/providers/docs_test.go
+++ b/pkg/providers/docs_test.go
@@ -7,20 +7,20 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/shipyard-run/shipyard/pkg/clients/mocks"
+	"github.com/shipyard-run/shipyard/pkg/clients"
 	"github.com/shipyard-run/shipyard/pkg/config"
 	"github.com/shipyard-run/shipyard/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-func setupDocs(t *testing.T) (*Docs, *mocks.MockContainerTasks) {
+func setupDocs(t *testing.T) (*Docs, *clients.MockContainerTasks) {
 	cc := config.NewDocs("tests")
 	cc.IndexTitle = "test"
 	cc.IndexPages = []string{"abc", "123"}
 	cc.Path = "./docs"
 
-	md := &mocks.MockContainerTasks{}
+	md := &clients.MockContainerTasks{}
 
 	md.On("PullImage", mock.Anything, false).Return(nil)
 	md.On("CreateContainer", mock.Anything).Return("", nil)

--- a/pkg/providers/exec_remote_test.go
+++ b/pkg/providers/exec_remote_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/shipyard-run/shipyard/pkg/clients/mocks"
+	"github.com/shipyard-run/shipyard/pkg/clients"
 	"github.com/shipyard-run/shipyard/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-func testRemoteExecSetupMocks() (*config.ExecRemote, *config.Network, *mocks.MockContainerTasks) {
-	md := &mocks.MockContainerTasks{}
+func testRemoteExecSetupMocks() (*config.ExecRemote, *config.Network, *clients.MockContainerTasks) {
+	md := &clients.MockContainerTasks{}
 	md.On("CreateContainer", mock.Anything).Return("1234", nil)
 	md.On("PullImage", mock.Anything, mock.Anything).Return(nil)
 	md.On("FindContainerIDs", mock.Anything).Return([]string{"1234"}, nil)

--- a/pkg/providers/image_cache_test.go
+++ b/pkg/providers/image_cache_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/hashicorp/go-hclog"
+	"github.com/shipyard-run/shipyard/pkg/clients"
 	"github.com/shipyard-run/shipyard/pkg/clients/mocks"
 	"github.com/shipyard-run/shipyard/pkg/config"
 	"github.com/shipyard-run/shipyard/pkg/utils"
@@ -14,12 +15,12 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func setupImageCacheTests(t *testing.T) (*config.ImageCache, *mocks.MockContainerTasks, *mocks.MockHTTP) {
+func setupImageCacheTests(t *testing.T) (*config.ImageCache, *clients.MockContainerTasks, *mocks.MockHTTP) {
 	c := config.New()
 	cc := config.NewImageCache("tests")
 	c.AddResource(cc)
 
-	md := &mocks.MockContainerTasks{}
+	md := &clients.MockContainerTasks{}
 	hc := &mocks.MockHTTP{}
 
 	md.On("CreateContainer", mock.Anything).Once().Return("abc", nil)

--- a/pkg/providers/legacy_ingress_test.go
+++ b/pkg/providers/legacy_ingress_test.go
@@ -5,15 +5,15 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/shipyard-run/shipyard/pkg/clients/mocks"
+	"github.com/shipyard-run/shipyard/pkg/clients"
 	"github.com/shipyard-run/shipyard/pkg/config"
 	"github.com/shipyard-run/shipyard/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-func testIngressCreateMocks() (*mocks.MockContainerTasks, *config.Config) {
-	md := &mocks.MockContainerTasks{}
+func testIngressCreateMocks() (*clients.MockContainerTasks, *config.Config) {
+	md := &clients.MockContainerTasks{}
 	md.On("PullImage", mock.Anything, mock.Anything).Return(nil)
 	md.On("CreateContainer", mock.Anything).Return("ingress", nil)
 	md.On("RemoveContainer", mock.Anything, true).Return(nil)
@@ -51,7 +51,7 @@ func testIngressCreateMocks() (*mocks.MockContainerTasks, *config.Config) {
 }
 
 func TestIngressK8sErrorsWhenUnableToLookupIDs(t *testing.T) {
-	md := &mocks.MockContainerTasks{}
+	md := &clients.MockContainerTasks{}
 	md.On("FindContainerIDs", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("boom"))
 
 	p := NewK8sIngress(&testK8sIngressConfig, md, hclog.NewNullLogger())
@@ -61,7 +61,7 @@ func TestIngressK8sErrorsWhenUnableToLookupIDs(t *testing.T) {
 }
 
 func TestIngressK8sErrorsWhenClusterExists(t *testing.T) {
-	md := &mocks.MockContainerTasks{}
+	md := &clients.MockContainerTasks{}
 	md.On("FindContainerIDs", mock.Anything, mock.Anything).Return([]string{"abc"}, nil)
 
 	p := NewK8sIngress(&testK8sIngressConfig, md, hclog.NewNullLogger())


### PR DESCRIPTION
Update Nomad to version 1.4
Fix the bug where K3s will not run if the Docker Engine storage is not overlay or overlay 2
Update K3s to version v1.23.12