### PR TITLE
Remove data folder using alpine container

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"github.com/jumppad-labs/jumppad/pkg/clients"
+	"github.com/jumppad-labs/jumppad/pkg/clients/container"
 	"github.com/jumppad-labs/jumppad/pkg/clients/connector"
 	"github.com/jumppad-labs/jumppad/pkg/clients/logger"
 	"github.com/jumppad-labs/jumppad/pkg/utils"
@@ -57,10 +59,24 @@ func newDestroyCmd(cc connector.Connector, l logger.Logger) *cobra.Command {
 				return
 			}
 
-			// clean up the data folders
-			os.RemoveAll(utils.DataFolder("", os.ModePerm))
-			os.RemoveAll(utils.LibraryFolder("", os.ModePerm))
-			os.RemoveAll(utils.JumppadTemp())
+			// Clean up the data folder. Containers managed by Jumppad (for
+			// example Vault) may have written files into a mounted data folder
+			// using a UID that does not belong to the host user, so host side
+			// removal will fail with EPERM. Run a short lived alpine container
+			// to remove the folder as root.
+			dataPath := filepath.Join(utils.JumppadHome(), "data")
+			if _, err := os.Stat(dataPath); err == nil {
+				if cerr := container.CleanupHostPath(engineClients.ContainerTasks, logger, dataPath); cerr != nil {
+					logger.Error("Unable to clean data folder", "path", dataPath, "error", cerr)
+				}
+			}
+
+			if err := os.RemoveAll(utils.LibraryFolder("", os.ModePerm)); err != nil {
+				logger.Error("Unable to remove library folder", "error", err)
+			}
+			if err := os.RemoveAll(utils.JumppadTemp()); err != nil {
+				logger.Error("Unable to remove temp folder", "error", err)
+			}
 
 			// shutdown ingress when we destroy all resources
 			if cc.IsRunning() {

--- a/pkg/clients/container/cleanup.go
+++ b/pkg/clients/container/cleanup.go
@@ -1,0 +1,85 @@
+package container
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/jumppad-labs/jumppad/pkg/clients/container/types"
+	"github.com/jumppad-labs/jumppad/pkg/clients/logger"
+)
+
+// cleanupImage is the image used by CleanupHostPath to remove a host path.
+const cleanupImage = "alpine:latest"
+
+// CleanupHostPath removes hostPath (the folder itself and everything inside
+// it) by running a short lived alpine container that bind mounts the parent
+// of hostPath at /parent and deletes the target as the container root user.
+//
+// This is required because Jumppad managed containers (for example Vault) may
+// write files into a mounted data folder using a UID that does not belong to
+// the host user, which causes host side os.RemoveAll to fail with EPERM. The
+// parent of hostPath is mounted, rather than hostPath itself, so the target
+// folder can be unlinked from inside the container — a bind mount point
+// cannot remove itself.
+//
+// TODO: this mirrors the previous host side behaviour of wiping the entire
+// data folder. A future version should only remove folders referenced by the
+// current config.
+func CleanupHostPath(ct ContainerTasks, l logger.Logger, hostPath string) error {
+	parent := filepath.Dir(hostPath)
+	target := filepath.Base(hostPath)
+
+	if err := ct.PullImage(types.Image{Name: cleanupImage}, false); err != nil {
+		return fmt.Errorf("unable to pull %s for host path cleanup: %w", cleanupImage, err)
+	}
+
+	cc := &types.Container{
+		Name:  fmt.Sprintf("jumppad-cleanup-%d", time.Now().UnixNano()),
+		Image: &types.Image{Name: cleanupImage},
+		Volumes: []types.Volume{
+			{
+				Source:      parent,
+				Destination: "/parent",
+				Type:        "bind",
+			},
+		},
+		Command: []string{"tail", "-f", "/dev/null"},
+	}
+
+	id, err := ct.CreateContainer(cc)
+	if err != nil {
+		return fmt.Errorf("unable to create cleanup container: %w", err)
+	}
+	defer func() {
+		if rerr := ct.RemoveContainer(id, true); rerr != nil {
+			l.Warn("Unable to remove cleanup container", "id", id, "error", rerr)
+		}
+	}()
+
+	// Wait for the container to be ready to accept an exec. ContainerInfo
+	// returns an opaque interface so the simplest portable readiness check is
+	// to retry a trivial command until it succeeds.
+	var readyErr error
+	for range 10 {
+		_, readyErr = ct.ExecuteCommand(id, []string{"true"}, nil, "/", "", "", 10, nil)
+		if readyErr == nil {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if readyErr != nil {
+		return fmt.Errorf("cleanup container did not become ready: %w", readyErr)
+	}
+
+	if _, err := ct.ExecuteCommand(
+		id,
+		[]string{"rm", "-rf", filepath.ToSlash(filepath.Join("/parent", target))},
+		nil, "/", "", "", 300, nil,
+	); err != nil {
+		return fmt.Errorf("unable to remove %s via cleanup container: %w", hostPath, err)
+	}
+
+	l.Debug("Cleaned up host path via container", "path", hostPath)
+	return nil
+}


### PR DESCRIPTION
When using the `data("name")` feature to create a temporary data folder and then mount it into a container, if any files are written with a different user than the one running jumppad then jumppad will fail to remove these when `down` is called.

This fix uses a temporary alpine linux container to remove all `data` folders when calling down. 